### PR TITLE
Fix Trainer argument name

### DIFF
--- a/test2/train_lora.py
+++ b/test2/train_lora.py
@@ -104,7 +104,7 @@ def main(cfg: TrainConfig) -> None:
 
     trainer = SFTTrainer(
         model=model,
-        tokenizer=tokenizer,
+        processing_class=tokenizer,
         train_dataset=train_ds,
         eval_dataset=eval_ds,
         peft_config=lora_cfg,


### PR DESCRIPTION
## Summary
- use `processing_class` when instantiating `SFTTrainer` to match new TRL API

## Testing
- `pytest -q` *(fails: `Trainer requires the PyTorch library`)*

------
https://chatgpt.com/codex/tasks/task_e_686cc190ee58832b9d528b886c198202