### PR TITLE
Fix training script compatibility with PyTorch <2.1

### DIFF
--- a/test2/train_lora.py
+++ b/test2/train_lora.py
@@ -6,6 +6,11 @@ from dataclasses import dataclass
 import inspect
 
 import torch
+import torch.optim.lr_scheduler as lr_sched
+
+if not hasattr(lr_sched, "LRScheduler"):
+    lr_sched.LRScheduler = lr_sched._LRScheduler
+
 from datasets import Dataset
 from peft import LoraConfig
 from transformers import (


### PR DESCRIPTION
## Summary
- alias `_LRScheduler` as `LRScheduler` if not available for older PyTorch

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dc129b064832bad99405f6920ea92