### PR TITLE
Return reasoning in teacher inference

### DIFF
--- a/test1/teacher_labeler.py
+++ b/test1/teacher_labeler.py
@@ -20,7 +20,7 @@ def label_samples(
     labeled: list[dict[str, Any]] = []
     with path.open("w", encoding="utf-8") as f:
         for prompt in prompts:
-            answer = call_teacher(prompt)
+            answer = call_teacher(prompt)["content"]
             try:
                 label = json.loads(answer)
             except json.JSONDecodeError:

--- a/test2/teacher_labeler.py
+++ b/test2/teacher_labeler.py
@@ -20,7 +20,7 @@ def label_samples(
     labeled: list[dict[str, Any]] = []
     with path.open("w", encoding="utf-8") as f:
         for prompt in prompts:
-            answer = call_teacher(prompt)
+            answer = call_teacher(prompt)["content"]
             try:
                 label = json.loads(answer)
             except json.JSONDecodeError:


### PR DESCRIPTION
## Summary
- update inference `call_teacher` to return both content and optional reasoning
- adjust CLI printing to handle new call_teacher return format
- update teacher_labeler to parse new response structure

## Testing
- `black test1/inference.py test2/inference.py test1/teacher_labeler.py test2/teacher_labeler.py`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e196a371c832bb5b463c16c35a0cb