### PR TITLE
Support reasoning field during cleaning

### DIFF
--- a/test2/clean_jsonl.py
+++ b/test2/clean_jsonl.py
@@ -14,11 +14,16 @@ def normalize_label(lab):
 
     # 字典：必须含有 prediction / analysis / advice 任一键
     if isinstance(lab, dict):
-        if any(
+        has_main = any(
             isinstance(lab.get(k), str) and lab[k].strip()
             for k in ("prediction", "analysis", "advice")
-        ):
-            return json.dumps(lab, ensure_ascii=False)
+        )
+        if has_main:
+            return (
+                lab
+                if "reasoning" in lab
+                else json.dumps(lab, ensure_ascii=False)
+            )
 
     return None  # 其它类型无效
 


### PR DESCRIPTION
## Summary
- keep dict labels intact when they include `reasoning`
- update all clean_jsonl scripts

## Testing
- `flake8 Cleaner.py test1/clean_jsonl.py test2/clean_jsonl.py`
- `black Cleaner.py test1/clean_jsonl.py test2/clean_jsonl.py`
- `TRANSFORMERS_NO_TORCH=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e1f8e2010832bbb526b43404e3279