### PR TITLE
Fix JSON label parsing

### DIFF
--- a/test2/teacher_labeler.py
+++ b/test2/teacher_labeler.py
@@ -21,12 +21,13 @@ def label_samples(
     with path.open("w", encoding="utf-8") as f:
         for prompt in prompts:
             ans = call_teacher(prompt)
+            answer = ans.get("content", ans) if isinstance(ans, dict) else ans
             try:
-                label = json.loads(ans["content"])
-                if ans["reasoning"]:
-                    label["reasoning"] = ans["reasoning"]
-            except json.JSONDecodeError:
-                label = {"raw": ans["content"], "reasoning": ans["reasoning"]}
+                label = json.loads(answer)
+            except (TypeError, json.JSONDecodeError):
+                label = {"raw": answer}
+            if isinstance(ans, dict) and ans.get("reasoning"):
+                label["reasoning"] = ans["reasoning"]
             record = {"prompt": prompt, "label": label}
             labeled.append(record)
             f.write(json.dumps(record, ensure_ascii=False) + "\n")


### PR DESCRIPTION
## Summary
- make teacher_labeler robust to teacher responses that are already dicts

## Testing
- `TRANSFORMERS_NO_TORCH=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874b811ccc8832b90f26c17042de5fe