### PR TITLE
Add max-tokens option for compare_sample

### DIFF
--- a/test1/compare_sample.py
+++ b/test1/compare_sample.py
@@ -21,6 +21,12 @@ def main() -> None:
     parser.add_argument("--index", type=int, default=0, help="Sample index to evaluate")
     parser.add_argument("--base-model", default="Qwen/Qwen1.5-0.5B", help="Base student model name or path")
     parser.add_argument("--tuned-model", required=True, help="Fine-tuned model path")
+    parser.add_argument(
+        "--max-tokens",
+        type=int,
+        default=256,
+        help="Maximum tokens to generate for each model",
+    )
     args = parser.parse_args()
 
     record = load_sample(args.data, args.index)
@@ -38,8 +44,12 @@ def main() -> None:
     base_tok, base_model = load_student(args.base_model)
     tuned_tok, tuned_model = load_student(args.tuned_model)
 
-    base_out = call_student(base_tok, base_model, prompt)
-    tuned_out = call_student(tuned_tok, tuned_model, prompt)
+    base_out = call_student(
+        base_tok, base_model, prompt, max_new_tokens=args.max_tokens
+    )
+    tuned_out = call_student(
+        tuned_tok, tuned_model, prompt, max_new_tokens=args.max_tokens
+    )
 
     print("Base model output:")
     print(base_out)


### PR DESCRIPTION
## Summary
- allow specifying max generation length when comparing models

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875f16edf3c832ba94d9a373084cfb1