### PR TITLE
Update cleaning for optional reasoning

### DIFF
--- a/test6/clean_jsonl.py
+++ b/test6/clean_jsonl.py
@@ -19,11 +19,10 @@ def normalize_label(lab):
             for k in ("prediction", "analysis", "advice")
         )
         if has_main:
-            return (
-                lab
-                if "reasoning" in lab
-                else json.dumps(lab, ensure_ascii=False)
-            )
+            if "reasoning" in lab:
+                if not (isinstance(lab["reasoning"], str) and lab["reasoning"].strip()):
+                    lab.pop("reasoning", None)
+            return json.dumps(lab, ensure_ascii=False)
 
     return None  # 其它类型无效
 

--- a/test6/distill.py
+++ b/test6/distill.py
@@ -25,7 +25,10 @@ def _clean(src: str | Path) -> str:
     src = Path(src)
     if not src.exists():
         sys.exit(f"[distill] ❌ 找不到 {src}")
-    dst = src.with_name(f"cleaned_{src.name}")
+    if src.name.endswith("-teacher.jsonl"):
+        dst = src.with_name(src.name.replace("-teacher.jsonl", "-cleaned.jsonl"))
+    else:
+        dst = src.with_name(f"cleaned_{src.name}")
     print(f"[distill] 清洗 {src.name} → {dst.name}")
     clean_jsonl_once(src, dst)
     return str(dst)
@@ -94,8 +97,10 @@ def run_pipeline(
     else:
         print("[distill] ▶ 跳过教师标注，使用现有 JSONL")
 
-    # 4) 清洗（仅 DeepSeek 结果用于训练）
+    # 4) 清洗各教师输出（仅 DeepSeek 结果用于训练）
     train_jsonl = _clean("D-teacher.jsonl")
+    _clean("G-teacher.jsonl")
+    _clean("Q-teacher.jsonl")
     val_jsonl = None
 
     # 5) LoRA 训练


### PR DESCRIPTION
## Summary
- sync clean_jsonl.py into test6 and relax reasoning requirement
- produce cleaned outputs for all teacher files in test6 pipeline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881d9c3cc18832bbeba35fcdfb5bef7