### PR TITLE
Add top-level pipeline target

### DIFF
--- a/test7/Makefile
+++ b/test7/Makefile
@@ -1,4 +1,12 @@
-.PHONY: data teacher hidden logits gkd eval
+.PHONY: all data teacher hidden logits gkd eval
+
+all: ## Run the full pipeline
+	$(MAKE) data
+	$(MAKE) teacher
+	$(MAKE) hidden
+	$(MAKE) logits
+	$(MAKE) gkd
+	$(MAKE) eval
 
 data:
 	python scripts/fetch_eastmoney.py --cfg configs/data.yaml


### PR DESCRIPTION
## Summary
- Add an `all` target in `test7/Makefile` to run data, teacher, hidden, logits, gkd, and eval sequentially.

## Testing
- `make -n all`
- `pytest` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_6899693dc4d8832b9761b245882aa44a