### PR TITLE
Export PYTHONPATH for test7 scripts

### DIFF
--- a/test7/Makefile
+++ b/test7/Makefile
@@ -1,4 +1,7 @@
+
 .PHONY: all data teacher hidden logits gkd eval
+
+export PYTHONPATH := $(PWD)
 
 all: ## Run the full pipeline
 	$(MAKE) data


### PR DESCRIPTION
## Summary
- ensure test7 scripts can import internal modules by exporting PYTHONPATH in Makefile

## Testing
- `make data` *(fails: AttributeError: 'NoneType' object has no attribute 'get')*
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689aab75ada0832ba88e6811fa1390af