### PR TITLE
fix: set correct pythonpath in test7 makefile

### DIFF
--- a/test7/Makefile
+++ b/test7/Makefile
@@ -1,7 +1,7 @@
 
 .PHONY: all data teacher hidden logits gkd eval
 
-export PYTHONPATH := $(PWD)
+export PYTHONPATH := $(CURDIR)
 
 all: ## Run the full pipeline
 	$(MAKE) data


### PR DESCRIPTION
## Summary
- export `PYTHONPATH` using `$(CURDIR)` so imports in test7 resolve correctly

## Testing
- `PYTHONPATH=. pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_689aadcd8070832b9711fb6b82966dca