### PR TITLE
Fix missing teacher schema import in test7

### DIFF
--- a/test7/src/teacher/postprocess.py
+++ b/test7/src/teacher/postprocess.py
@@ -1,7 +1,7 @@
 """
 老师输出的 JSON 清洗、字段补齐、与 prompt 对齐。
 """
-from .schema import TeacherJSON
+from ..data.schema import TeacherJSON
 
 
 def normalize_teacher_json(obj: dict) -> TeacherJSON:


### PR DESCRIPTION
## Summary
- fix ModuleNotFoundError by importing TeacherJSON from shared data schema

## Testing
- `pytest tests`
- `PYTHONPATH=test7 pytest test7/tests`


------
https://chatgpt.com/codex/tasks/task_e_689ab89c5064832bb274dfde72e2d76a