### PR TITLE
Handle missing prediction in teacher inference

### DIFF
--- a/test7/src/teacher/vllm_offline.py
+++ b/test7/src/teacher/vllm_offline.py
@@ -72,5 +72,8 @@ def ensure_json(output_str: str, schema_path: str) -> Dict:
             "analysis": data.get("analysis", ""),
             "advice": data.get("advice", ""),
         }
+        allowed = schema.get("properties", {}).get("prediction", {}).get("enum", [])
+        if cleaned["prediction"] not in allowed:
+            cleaned["prediction"] = "flat"
         jsonschema.validate(cleaned, schema)
         return cleaned


### PR DESCRIPTION
## Summary
- Default teacher JSON `prediction` field to `flat` when model output is invalid

## Testing
- `make data`
- `PYTHONPATH=. python scripts/run_teacher_infer.py --cfg configs/teacher_infer.yaml`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ad9734b64832b83147cf637e926df