### PR TITLE
fix accelerate config for hidden distillation

### DIFF
--- a/test7/configs/accelerate_ds_zero3.yaml
+++ b/test7/configs/accelerate_ds_zero3.yaml
@@ -1,0 +1,9 @@
+compute_environment: LOCAL_MACHINE
+distributed_type: DEEPSPEED
+num_processes: 1
+num_machines: 1
+machine_rank: 0
+gpu_ids: all
+mixed_precision: bf16
+deepspeed_config: configs/deepspeed_zero3.json
+

--- a/test7/scripts/train_hidden_kd.sh
+++ b/test7/scripts/train_hidden_kd.sh
@@ -3,4 +3,4 @@
 # 关键变量: TEACHER/STUDENT/OUTPUT_DIR/EPOCHS/BF16/FA/DS_CONFIG
 # 参考 DistillKit 官方 README 的启动方式
 
-accelerate launch --config_file configs/deepspeed_zero3.json distil_hidden.py --config configs/distill_hidden.yaml "$@"
+accelerate launch --config_file configs/accelerate_ds_zero3.yaml distil_hidden.py --config configs/distill_hidden.yaml "$@"

--- a/test7/src/distill/hidden_kd.py
+++ b/test7/src/distill/hidden_kd.py
@@ -11,7 +11,7 @@ def launch_hidden_kd(config: Dict):
     :param config: 读取 configs/distill_hidden.yaml
     调用 accelerate + DistillKit 的 distil_hidden.py
     """
-    cfg_path = config.get("config_path", "configs/distill_hidden.yaml")
+    cfg_path = config.get("config_path", "configs/accelerate_ds_zero3.yaml")
     cmd = [
         "accelerate",
         "launch",
@@ -19,6 +19,9 @@ def launch_hidden_kd(config: Dict):
         cfg_path,
         config.get("script", "distil_hidden.py"),
     ]
+    distill_cfg = config.get("distill_config", "configs/distill_hidden.yaml")
+    if distill_cfg:
+        cmd.extend(["--config", distill_cfg])
     extra = config.get("extra_args") or []
     if isinstance(extra, dict):
         for k, v in extra.items():


### PR DESCRIPTION
## Summary
- add accelerate configuration with distributed_type deepspeed
- reference new config from train_hidden_kd script and wrapper

## Testing
- `PYTHONPATH=test7 pytest test7/tests`


------
https://chatgpt.com/codex/tasks/task_e_689adfff5d08832ba37dd7fa56f00c4f