### PR TITLE
Fix accelerate deepspeed config

### DIFF
--- a/test7/configs/accelerate_ds_zero3.yaml
+++ b/test7/configs/accelerate_ds_zero3.yaml
@@ -5,5 +5,6 @@ num_machines: 1
 machine_rank: 0
 gpu_ids: all
 mixed_precision: bf16
-deepspeed_config: configs/deepspeed_zero3.json
+deepspeed_config:
+  hf_ds_config: configs/deepspeed_zero3.json
 


### PR DESCRIPTION
## Summary
- fix accelerate config to pass DeepSpeed config as `hf_ds_config`

## Testing
- `PYTHONPATH=$PWD pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_689ae48ab6a4832bb0e9acad4d3d4196