### PR TITLE
feat(test7): improve kline fetch and distill script

### DIFF
--- a/test7/scripts/fetch_eastmoney.py
+++ b/test7/scripts/fetch_eastmoney.py
@@ -9,7 +9,7 @@ import json
 from pathlib import Path
 import yaml
 
-from src.data.eastmoney_client import to_secid, fetch_kline
+from src.data.eastmoney_client import to_secid, fetch_kline, EastMoneyAPI
 
 
 def parse_args():
@@ -27,7 +27,20 @@ def main():
     symbols = args.symbols or cfg.get("symbols", [])
     output_dir = Path(cfg.get("output_dir", "data/raw"))
     output_dir.mkdir(parents=True, exist_ok=True)
+
+    api = EastMoneyAPI()
     for sym in symbols:
+        # 连通性测试：尝试获取最近1天数据
+        test_df = api.get_kline_data(sym, num=1)
+        if test_df.empty:
+            print(f"[测试] 股票{sym} 最新行情获取失败！")
+        else:
+            latest = test_df.iloc[-1]
+            print(
+                f"[测试] 股票{sym} 最新日期: {latest['date'].date()}, 收盘价: {latest['close']}"
+            )
+
+        # 仍使用原始接口抓取并保存原始 JSON，以保持下游兼容
         secid = to_secid(sym)
         data = fetch_kline(
             secid,

--- a/test7/scripts/train_hidden_kd.sh
+++ b/test7/scripts/train_hidden_kd.sh
@@ -3,4 +3,4 @@
 # 关键变量: TEACHER/STUDENT/OUTPUT_DIR/EPOCHS/BF16/FA/DS_CONFIG
 # 参考 DistillKit 官方 README 的启动方式
 
-accelerate launch --config_file configs/accelerate_ds_zero3.yaml distil_hidden.py --config configs/distill_hidden.yaml "$@"
+python -m src.distill.hidden_kd --config configs/distill_hidden.yaml "$@"


### PR DESCRIPTION
## Summary
- add dataframe-based EastMoneyAPI with batch helper
- enhance eastmoney fetch script with connectivity check
- fix hidden KD launcher by locating DistillKit script and providing CLI

## Testing
- `cd test7 && PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689aefb1c09c832b9c28a608710aa1dd