### PR TITLE
Refactor dataset builder to include kline summaries

### DIFF
--- a/test7/src/data/schema.py
+++ b/test7/src/data/schema.py
@@ -4,7 +4,7 @@ from typing import Literal, Optional
 
 class PromptItem(BaseModel):
     stock_code: str
-    summary: str
+    kline_summary: list[dict]
     change: float
     prompt: str  # 套用统一模板的最终提示串
 

--- a/test7/tests/test_schema.py
+++ b/test7/tests/test_schema.py
@@ -3,5 +3,8 @@ from src.data.schema import PromptItem, TeacherJSON, Record
 
 
 def test_prompt_item_fields():
-    item = PromptItem(stock_code="000001", summary="demo", change=0.0, prompt="test")
+    item = PromptItem(
+        stock_code="000001", kline_summary=[], change=0.0, prompt="test"
+    )
     assert item.stock_code == "000001"
+    assert item.kline_summary == []


### PR DESCRIPTION
## Summary
- Generate prompts using new `format_prompt` helper that embeds JSON K-line summaries and change.
- Compute `kline_summary` with required fields and return it alongside the prompt.
- Extend `PromptItem` schema and tests to expose the new `kline_summary` field.

## Testing
- `PYTHONPATH=. pytest tests/test_schema.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689bf90a7ad8832b8070d71df66acdbc