### PR TITLE
refactor: include change once in prompt template

### DIFF
--- a/test7/configs/data.yaml
+++ b/test7/configs/data.yaml
@@ -13,5 +13,5 @@ summary:
   indicators: ["ret_30","volatility","ma_5_10_20","bias","volume_divergence","sr_levels"]
 save_dir: "data"
 template: |
-  股票 {stock_code} 近30日K线数据: {summary}
+  股票 {stock_code} 近30日K线数据: {kline_json}
   涨跌幅: {change}%。请预测后市走势，给出简短分析和操作建议，并以 JSON 格式回复，包括 'prediction', 'analysis', 'advice' 三个字段。

--- a/test7/scripts/build_dataset.py
+++ b/test7/scripts/build_dataset.py
@@ -1,5 +1,5 @@
 """
-将 raw K 线转为 processed 样本，生成 prompt/summary/change
+将 raw K 线转为 processed 样本，生成 prompt/kline_json/change
 并时间滚动切分，导出 data/processed/*.jsonl 与 data/splits/*
 """
 import argparse

--- a/test7/src/data/schema.py
+++ b/test7/src/data/schema.py
@@ -4,7 +4,7 @@ from typing import Literal, Optional
 
 class PromptItem(BaseModel):
     stock_code: str
-    kline_summary: list[dict]
+    kline_json: list[dict]
     change: float
     prompt: str  # 套用统一模板的最终提示串
 

--- a/test7/tests/test_schema.py
+++ b/test7/tests/test_schema.py
@@ -4,7 +4,7 @@ from src.data.schema import PromptItem, TeacherJSON, Record
 
 def test_prompt_item_fields():
     item = PromptItem(
-        stock_code="000001", kline_summary=[], change=0.0, prompt="test"
+        stock_code="000001", kline_json=[], change=0.0, prompt="test"
     )
     assert item.stock_code == "000001"
-    assert item.kline_summary == []
+    assert item.kline_json == []


### PR DESCRIPTION
## Summary
- refactor prompt builder to pass `change` only through `format_prompt` and rename summary payload to `kline_json`
- update data template to show 30-day K-line JSON and remove duplicate change values
- adjust schema and tests for new `kline_json` field

## Testing
- `PYTHONPATH=test7 pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c012df5e4832b90c20b0c9cfc1dc3