### PR TITLE
Improve Eastmoney kline parsing and logging

### DIFF
--- a/test7/scripts/fetch_eastmoney.py
+++ b/test7/scripts/fetch_eastmoney.py
@@ -7,6 +7,7 @@ import argparse
 
 import json
 from pathlib import Path
+import logging
 import yaml
 
 from src.data.eastmoney_client import (
@@ -19,6 +20,9 @@ import pandas as pd
 import numpy as np
 
 
+logger = logging.getLogger(__name__)
+
+
 def parse_args():
     """解析命令行参数。"""
     parser = argparse.ArgumentParser()
@@ -28,6 +32,7 @@ def parse_args():
 
 
 def main():
+    logging.basicConfig(level=logging.INFO)
     args = parse_args()
     with open(args.cfg, "r", encoding="utf-8") as f:
         cfg = yaml.safe_load(f)
@@ -38,12 +43,16 @@ def main():
     api = EastMoneyAPI()
     for sym in symbols:
         # 连通性测试：尝试获取最近1天数据
-        test_df = api.get_kline_data(sym, num=1)
+        try:
+            test_df = api.get_kline_data(sym, num=1)
+        except Exception as e:  # 网络或解析异常
+            logger.error(f"[测试] 股票{sym} 最新行情获取失败: {e}")
+            continue
         if test_df.empty:
-            print(f"[测试] 股票{sym} 最新行情获取失败！")
+            logger.warning(f"[测试] 股票{sym} 最新行情获取失败！")
         else:
             latest = test_df.iloc[-1]
-            print(
+            logger.info(
                 f"[测试] 股票{sym} 最新日期: {latest['date'].date()}, 收盘价: {latest['close']}"
             )
 
@@ -56,12 +65,16 @@ def main():
             cfg.get("klt", 101),
             cfg.get("fqt", 1),
         )
-        rows = parse_kline_json(data)
+        try:
+            rows = parse_kline_json(data)
+        except ValueError as e:
+            logger.error(f"股票{sym} 数据解析失败: {e}")
+            continue
         df = pd.DataFrame(rows)
         df.replace([np.inf, -np.inf], np.nan, inplace=True)
         df.dropna(subset=["close", "volume"], inplace=True)
         if df.empty:
-            print(f"[警告] 股票{sym} 无有效数据，已跳过保存")
+            logger.warning(f"股票{sym} 无有效数据，已跳过保存")
             continue
         # 重建原始 JSON 结构，以便下游 parse_kline_json 解析
         klines = [


### PR DESCRIPTION
## Summary
- add detailed logging and error propagation in `parse_kline_json`
- log parsing stats and surface warnings via `fetch_eastmoney.py`

## Testing
- `PYTHONPATH=. pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_689c05a293cc832b8ecde71084a8fc23