### PR TITLE
feat: add dataset builder

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ numpy==2.3.1
 streamlit==1.46.1
 openai==1.93.0
 matplotlib==3.10.3
+pandas==2.2.2

--- a/test7/scripts/build_dataset.py
+++ b/test7/scripts/build_dataset.py
@@ -1,118 +1,63 @@
-"""
-将 raw K 线转为 processed 样本，生成 prompt/kline_json/change
-并时间滚动切分，导出 data/processed/*.jsonl 与 data/splits/*
-"""
-import argparse
+"""构建训练/验证集数据集并保存为 JSONL。
 
-import json
+该脚本从配置文件读取股票代码、模板等信息，
+调用 :func:`src.data.dataset_builder.build_dataset` 获取
+训练集和验证集的 :class:`PromptItem` 列表，
+并将结果写入 ``train.jsonl`` 与 ``val.jsonl``。
+"""
+
+from __future__ import annotations
+
+import argparse
 from pathlib import Path
 import yaml
 
-from src.utils.io import read_jsonl, write_jsonl
-from src.data.dataset_builder import build_prompts_from_kline, time_roll_split
-from src.data.eastmoney_client import parse_kline_json
+from src.data.dataset_builder import build_dataset, save_jsonl
 
 
-def parse_args():
-    """解析命令行参数。"""
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--cfg", type=str, help="配置文件路径")
-    parser.add_argument("--raw", help="原始K线数据目录", nargs="?")
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="build dataset")
+    parser.add_argument("--cfg", required=True, help="配置文件路径")
     return parser.parse_args()
 
 
-def main():
+def main() -> None:
     args = parse_args()
     with open(args.cfg, "r", encoding="utf-8") as f:
         cfg = yaml.safe_load(f)
-    raw_dir = Path(args.raw or cfg.get("raw_dir", "data/raw"))
+
+    symbols = cfg.get("symbols", [])
     template = cfg["template"]
-    tokenizer_name = cfg.get("tokenizer")
+    days = cfg.get("days", 180)
+    window = cfg.get("summary", {}).get("window_days", 30)
+    val_ratio = cfg.get("val_ratio", 0.2)
+    balance = cfg.get("balance", True)
     max_tokens = cfg.get("max_tokens", 1024)
+    tokenizer_name = cfg.get("tokenizer")
     tokenizer = None
     if tokenizer_name:
         from transformers import AutoTokenizer
 
         tokenizer = AutoTokenizer.from_pretrained(tokenizer_name)
-    all_items = []
 
-    raw_paths = list(raw_dir.glob("*.json"))
-    if not raw_paths:
-        print(f"[警告] 在 {raw_dir} 未找到本地JSON，尝试在线获取…")
-        from src.data.eastmoney_client import EastMoneyAPI
-        import pandas as pd
+    train_items, val_items = build_dataset(
+        symbols,
+        days=days,
+        window=window,
+        val_ratio=val_ratio,
+        balance=balance,
+        template=template,
+        tokenizer=tokenizer,
+        max_tokens=max_tokens,
+        seed=cfg.get("seed"),
+    )
 
-        api = EastMoneyAPI()
-        symbols = cfg.get("symbols", [])
-        for sym in symbols:
-            df = api.get_kline_data(sym)
-            if df is None or df.empty:
-                print(f"[警告] 股票 {sym} 在线获取失败，已跳过")
-                continue
-            df = df.copy()
-            if "date" in df.columns:
-                df["date"] = pd.to_datetime(df["date"]).dt.strftime("%Y-%m-%d")
-            kline = df.to_dict(orient="records")
-            for rec in kline:
-                rec["stock_code"] = sym
-            try:
-                item = build_prompts_from_kline(
-                    kline,
-                    template,
-                    tokenizer=tokenizer,
-                    max_tokens=max_tokens,
-                )
-            except ValueError as e:
-                print(f"[警告] {sym} 数据异常: {e}，已跳过")
-                continue
-            all_items.append(item)
-        if not all_items:
-            print("[警告] 未能在线获取任何K线数据")
-    else:
-        for path in raw_paths:
-            with open(path, "r", encoding="utf-8") as fr:
-                raw = json.load(fr)
-            kline = parse_kline_json(raw)
-            if not kline:
-                # 若原始 JSON 中无有效 K 线数据，则跳过该文件，避免生成空 prompt
-                print(f"[警告] {path.name} 无有效K线数据，已跳过")
-                continue
-            for rec in kline:
-                rec["stock_code"] = path.stem
-            try:
-                item = build_prompts_from_kline(
-                    kline,
-                    template,
-                    tokenizer=tokenizer,
-                    max_tokens=max_tokens,
-                )
-            except ValueError as e:
-                # 如果K线数据不足或含有NaN/inf等异常，跳过该样本
-                print(f"[警告] {path.name} 数据异常: {e}，已跳过")
-                continue
-            all_items.append(item)
-
-    if not all_items:
-        print("[警告] 未能从本地或远程获取任何样本")
-
-    df = cfg.get("dataframe")
-    if df is not None:
-        subsets = time_roll_split(df, cfg.get("splits", {}))
-    else:
-        subsets = {"all": all_items}
-
-    output_dir = Path(cfg.get("output_dir", "data/processed"))
-    output_dir.mkdir(parents=True, exist_ok=True)
-    if "all" in subsets:
-        # 当未提供显式划分时，默认生成 all.jsonl 和 train.jsonl
-        items = [i.model_dump() for i in all_items]
-        write_jsonl(items, output_dir / "all.jsonl")
-        # 兼容下游默认读取的 train.jsonl
-        write_jsonl(items, output_dir / "train.jsonl")
-    else:
-        for name, subset in subsets.items():
-            write_jsonl([i.model_dump() for i in subset], output_dir / f"{name}.jsonl")
+    out_dir = Path(cfg.get("save_dir", "data"))
+    out_dir.mkdir(parents=True, exist_ok=True)
+    save_jsonl(train_items, out_dir / "train.jsonl")
+    save_jsonl(val_items, out_dir / "val.jsonl")
 
 
 if __name__ == "__main__":
     main()
+

--- a/test7/src/data/dataset_builder.py
+++ b/test7/src/data/dataset_builder.py
@@ -110,3 +110,139 @@ def time_roll_split(df, cutoff_dates) -> dict:
     val = df[(df["date"] > train_end) & (df["date"] <= val_end)]
     test = df[df["date"] > val_end]
     return {"train": train, "val": val, "test": test}
+
+
+def build_dataset(
+    stock_codes,
+    *,
+    days: int = 180,
+    window: int = 30,
+    windows_per_stock: int | None = None,
+    val_ratio: float = 0.2,
+    balance: bool = True,
+    seed: int | None = None,
+    template: str = (
+        "股票 {stock_code} 近30日K线数据: {kline_json}\n"
+        "涨跌幅: {change}%。请预测后市走势，给出简短分析和操作建议，并以 JSON 格式回复，包括 'prediction', 'analysis', 'advice' 三个字段。"
+    ),
+    tokenizer=None,
+    max_tokens: int = 1024,
+):
+    """构建训练/验证集 PromptItem 列表。
+
+    通过 :class:`EastMoneyAPI` 获取每只股票最近 ``days`` 天的K线数据，
+    按 ``window`` 进行滑窗切片，并根据涨跌幅划分 up/down/stable 三类。
+    当 ``balance=True`` 时，会对三类样本进行下采样以保持平衡。
+    返回训练集与验证集两个 :class:`PromptItem` 列表。
+    """
+
+    import random
+    from typing import Sequence
+
+    from .eastmoney_client import EastMoneyAPI
+
+    try:  # optional heavy deps
+        import pandas as pd  # noqa: F401
+        import numpy as np  # noqa: F401
+    except Exception as e:  # pragma: no cover - runtime guard
+        raise ImportError("pandas and numpy are required for dataset building") from e
+
+    codes: Sequence[str] = list(stock_codes)
+    rng = random.Random(seed)
+    api = EastMoneyAPI()
+
+    up_items: list[PromptItem] = []
+    down_items: list[PromptItem] = []
+    stable_items: list[PromptItem] = []
+
+    for code in codes:
+        df = api.get_kline_data(code, num=days)
+        if df is None or df.empty:
+            continue
+
+        df["pct_chg"] = df["close"].pct_change() * 100
+        df["pct_chg"].fillna(0, inplace=True)
+        df["MA5"] = df["close"].rolling(5).mean()
+        df["MA10"] = df["close"].rolling(10).mean()
+        diff = df["close"].diff()
+        gains = diff.clip(lower=0)
+        losses = -diff.clip(upper=0)
+        avg_gain = gains.ewm(alpha=1 / 14, adjust=False).mean()
+        avg_loss = losses.ewm(alpha=1 / 14, adjust=False).mean()
+        rs = avg_gain / avg_loss
+        rsi = np.where(
+            avg_loss.to_numpy() == 0,
+            np.where(avg_gain.to_numpy() == 0, 50, 100),
+            100 - 100 / (1 + rs.to_numpy()),
+        )
+        df["RSI14"] = rsi
+        ema12 = df["close"].ewm(span=12, adjust=False).mean()
+        ema26 = df["close"].ewm(span=26, adjust=False).mean()
+        df["MACD"] = ema12 - ema26
+        df[["MA5", "MA10", "RSI14", "MACD"]] = df[
+            ["MA5", "MA10", "RSI14", "MACD"]
+        ].round(2)
+
+        n = len(df)
+        if n < window:
+            continue
+
+        valid_indices = [
+            i
+            for i in range(n - window + 1)
+            if not (
+                df["volume"].iloc[i : i + window].eq(0).any()
+                or df["pct_chg"].iloc[i : i + window].abs().gt(20).any()
+            )
+        ]
+        if windows_per_stock is not None and len(valid_indices) > windows_per_stock:
+            valid_indices = rng.sample(valid_indices, windows_per_stock)
+
+        for i in valid_indices:
+            win = df.iloc[i : i + window][
+                [
+                    "date",
+                    "open",
+                    "close",
+                    "high",
+                    "low",
+                    "volume",
+                    "MA5",
+                    "MA10",
+                    "RSI14",
+                    "MACD",
+                ]
+            ].reset_index(drop=True)
+            win["date"] = pd.to_datetime(win["date"]).dt.strftime("%Y-%m-%d")
+            win["stock_code"] = code
+
+            change_pct = ((win["close"].iloc[-1] / win["close"].iloc[0]) - 1) * 100
+            try:
+                item = build_prompts_from_kline(
+                    win.to_dict(orient="records"),
+                    template,
+                    tokenizer=tokenizer,
+                    max_tokens=max_tokens,
+                )
+            except ValueError:
+                continue
+            if change_pct > 3:
+                up_items.append(item)
+            elif change_pct < -3:
+                down_items.append(item)
+            else:
+                stable_items.append(item)
+
+    if balance and up_items and down_items and stable_items:
+        min_count = min(len(up_items), len(down_items), len(stable_items))
+        rng.shuffle(up_items)
+        rng.shuffle(down_items)
+        rng.shuffle(stable_items)
+        up_items = up_items[:min_count]
+        down_items = down_items[:min_count]
+        stable_items = stable_items[:min_count]
+
+    samples = up_items + down_items + stable_items
+    rng.shuffle(samples)
+    split = int(len(samples) * (1 - val_ratio))
+    return samples[:split], samples[split:]


### PR DESCRIPTION
## Summary
- implement build_dataset using EastMoneyAPI with sliding windows
- categorize windows and optionally balance classes
- script to build and save train/val JSONL datasets

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*


------
https://chatgpt.com/codex/tasks/task_e_689c07f9d760832bbe64d6c334b018d5