### PR TITLE
docs: clarify LoRA workflow and motivation in demo notebook

### DIFF
--- a/lora_finetune_demo.ipynb
+++ b/lora_finetune_demo.ipynb
@@ -2,6 +2,45 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "7129f2da",
+   "metadata": {},
+   "source": [
+    "```mermaid\n",
+    "flowchart LR\n",
+    "    A[dataset_builder] -->|原始样本| B[teacher_labeler]\n",
+    "    B -->|生成标签| C[train_lora]\n",
+    "    C -->|LoRA 模型| D[evaluate]\n",
+    "```\n",
+    "\n",
+    "以上示意图展示了各模块的协作关系：\n",
+    "- `dataset_builder`：收集与清洗数据，输出原始训练样本；\n",
+    "- `teacher_labeler`：调用教师模型，为样本添加 `prediction`、`analysis` 等标签；\n",
+    "- `train_lora`：基于带标签数据执行 LoRA 微调；\n",
+    "- `evaluate`：加载微调模型，在验证集上评估效果。"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f794a6f",
+   "metadata": {},
+   "source": [
+    "### LoRA 原理概述\n",
+    "LoRA（Low-Rank Adaptation）将权重增量表示为低秩分解 $\\Delta W = B A$，仅训练小矩阵 $A,B$，而预训练权重 $W_0$ 保持冻结不更新，从而在保持原模型能力的同时大幅减少可训练参数和显存开销。\n",
+    "\n",
+    "在本示例中，可选参数 `rope_factor` 会按比例缩放旋转位置编码（RoPE）的基础频率，以此扩展模型可接受的上下文长度；例如 `rope_factor=2` 时，理论上可将上下文窗口扩大到原来的两倍。"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c8d23965",
+   "metadata": {},
+   "source": [
+    "### 金融场景下的动机示例\n",
+    "在金融任务中，模型需理解长篇财报、行情序列并生成投资建议。通过 LoRA 微调，我们只需在少量行业数据上训练小规模适配器，即可快速获得专用模型；配合 `rope_factor` 扩展后的 RoPE，模型还能一次性读入更长的时间区间或多份文档。这为后续的数据构建、教师标注、训练与评估提供了现实动机。"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "cab46637",
    "metadata": {},
    "source": [


### PR DESCRIPTION
## Summary
- add mermaid diagram linking dataset builder, teacher labeler, LoRA training and evaluation modules
- expand on LoRA low-rank adaptation and `rope_factor` context extension
- motivate workflow with financial-domain example

## Testing
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_689d9ac9bbb8832bb564abeb41d70805