### PR TITLE
Refocus LoRA fine-tuning demo on test4 project

### DIFF
--- a/lora_finetune_demo.ipynb
+++ b/lora_finetune_demo.ipynb
@@ -7,16 +7,16 @@
    "source": [
     "```mermaid\n",
     "flowchart LR\n",
-    "    A[dataset_builder] -->|原始样本| B[teacher_labeler]\n",
-    "    B -->|生成标签| C[train_lora]\n",
-    "    C -->|LoRA 模型| D[evaluate]\n",
+    "    A[test4/dataset_builder] -->|原始样本| B[test4/teacher_labeler]\n",
+    "    B -->|生成标签| C[test4/train_lora]\n",
+    "    C -->|LoRA 模型| D[test4/evaluate]\n",
     "```\n",
     "\n",
-    "以上示意图展示了各模块的协作关系：\n",
-    "- `dataset_builder`：收集与清洗数据，输出原始训练样本；\n",
-    "- `teacher_labeler`：调用教师模型，为样本添加 `prediction`、`analysis` 等标签；\n",
-    "- `train_lora`：基于带标签数据执行 LoRA 微调；\n",
-    "- `evaluate`：加载微调模型，在验证集上评估效果。"
+    "以上示意图展示了 `test4` 项目中各模块的协作关系：\n",
+    "- `test4.dataset_builder`：收集与清洗数据，输出原始训练样本；\n",
+    "- `test4.teacher_labeler`：调用教师模型，为样本添加 `prediction`、`analysis` 等标签；\n",
+    "- `test4.train_lora`：基于带标签数据执行 LoRA 微调；\n",
+    "- `test4.evaluate`：加载微调模型，在验证集上评估效果。"
    ]
   },
   {
@@ -46,7 +46,7 @@
    "source": [
     "# 大模型 LoRA 微调流程演示\n",
     "\n",
-    "本示例 Notebook 展示金融股票领域大模型微调的完整流程，包括数据集构建、教师模型标注、LoRA 微调训练以及模型评估。示例使用 `test4` 模块中的代码，并利用模拟数据和模型以便在轻量环境下演示整体流程。"
+    "本示例 Notebook 展示金融股票领域大模型微调的完整流程，包括数据集构建、教师模型标注、LoRA 微调训练以及模型评估。示例完全依赖 `test4` 模块的代码，并利用模拟数据和模型以便在轻量环境下演示整体流程。其它测试模块（test1、test2、test3、test5、test6、test7）均未被调用。"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- Emphasize test4 modules in LoRA fine-tuning demo, updating diagrams and explanations
- Note that the notebook depends solely on test4 and does not invoke other test modules

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_689da1645df4832bb3c54f171f0067e9