### PR TITLE
Fix chained assignment warning in dataset builder

### DIFF
--- a/test4/dataset_builder.py
+++ b/test4/dataset_builder.py
@@ -108,7 +108,7 @@ def build_dataset(
             continue
         # --- Compute technical indicators and mark anomalies ---
         df["pct_chg"] = df["close"].pct_change() * 100
-        df["pct_chg"].fillna(0, inplace=True)
+        df["pct_chg"] = df["pct_chg"].fillna(0)
         df["MA5"] = df["close"].rolling(5).mean()
         df["MA10"] = df["close"].rolling(10).mean()
         differences = df["close"].diff()


### PR DESCRIPTION
## Summary
- avoid pandas chained assignment warning by replacing inplace fillna

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'src')*


------
https://chatgpt.com/codex/tasks/task_e_68a28406626c832b937438af2677775b