### PR TITLE
feat: allow hf endpoint config

### DIFF
--- a/test7/README.md
+++ b/test7/README.md
@@ -19,6 +19,13 @@
 在运行整体代码前，务必先装配好DistillKit环境（通过[github](https://github.com/arcee-ai/DistillKit)获取）
 指令`make -C test7 all`可一键执行蒸馏的全部过程。
 
+若无法直接访问 HuggingFace，可在 `configs/teacher_infer.yaml` 中设置 `hf_endpoint`
+为镜像站点（例如 `https://hf-mirror.com`）。脚本会自动读取该字段并
+设置 `HF_ENDPOINT` 环境变量，从而通过镜像下载模型与权重。
+
+若已提前下载好模型，也可在配置中填写 `model_path` 指向本地目录，
+脚本会优先使用该路径加载模型，避免联网。
+
 ## 参考
 - DistillKit: hidden/logits KD 及 DeepSpeed 示例。
 - TRL GKDTrainer 文档。

--- a/test7/configs/teacher_infer.yaml
+++ b/test7/configs/teacher_infer.yaml
@@ -1,4 +1,6 @@
-model_name: "Qwen/Qwen2.5-32B-Instruct-awq"   # 使用 AWQ 量化教师模型
+model_name: "Qwen/Qwen2.5-32B-Instruct-awq"   # HuggingFace 模型名称
+model_path: ""                                 # 如已下载到本地, 填写路径
+hf_endpoint: ""                                # 如需访问镜像站点, 填入其 URL
 engine: "vllm"                             # 使用 vLLM Offline Inference
 tensor_parallel_size: 2
 max_model_len: 32768

--- a/test7/scripts/run_teacher_infer.py
+++ b/test7/scripts/run_teacher_infer.py
@@ -5,6 +5,7 @@
 """
 
 import argparse
+import os
 
 import yaml
 from pathlib import Path
@@ -26,6 +27,13 @@ def main():
     with open(args.cfg, "r", encoding="utf-8") as f:
         cfg = yaml.safe_load(f)
 
+    if endpoint := cfg.get("hf_endpoint"):
+        os.environ.setdefault("HF_ENDPOINT", endpoint)
+
+    model_name = cfg.get("model_path") or cfg["model_name"]
+    if cfg.get("model_path"):
+        os.environ.setdefault("HF_HUB_OFFLINE", "1")
+
     # Structured config sections
     data_cfg = cfg.get("data", {})
     gen_cfg = cfg.get("generation", {})
@@ -46,7 +54,7 @@ def main():
 
     results = []
     for out in run_offline_infer(
-        cfg["model_name"],
+        model_name,
         prompts,
         gen_cfg.get("temperature", 0.7),
         gen_cfg.get("top_p", 0.9),


### PR DESCRIPTION
## Summary
- allow teacher inference script to set HF_ENDPOINT from config
- document mirror usage for offline environments
- support loading teacher model from a local directory to avoid Hugging Face access

## Testing
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68a41a11f46c832ba51e6029192a4da3