### PR TITLE
Add stock data loader and dataset utilities for test8

### DIFF
--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,0 +1,8 @@
+import sys
+import pathlib
+
+root = pathlib.Path(__file__).resolve().parent
+if str(root) not in sys.path:
+    sys.path.insert(0, str(root))
+if str(root / "test7") not in sys.path:
+    sys.path.insert(0, str(root / "test7"))

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,5 @@
+"""Proxy package exposing ``test7/src`` modules for unit tests."""
+
+import pathlib
+
+__path__ = [str(pathlib.Path(__file__).resolve().parent.parent / "test7" / "src")]

--- a/test7/tests/sitecustomize.py
+++ b/test7/tests/sitecustomize.py
@@ -1,0 +1,8 @@
+import sys
+import pathlib
+
+root = pathlib.Path(__file__).resolve().parents[2]
+if str(root) not in sys.path:
+    sys.path.insert(0, str(root))
+if str(root / "test7") not in sys.path:
+    sys.path.insert(0, str(root / "test7"))

--- a/test8/clean_jsonl.py
+++ b/test8/clean_jsonl.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+"""Remove records without valid ``prompt``/``label`` fields from a JSONL file."""
+
+import argparse
+import json
+import pathlib
+from collections import Counter
+
+
+def normalize_label(lab):
+    if isinstance(lab, str) and lab.strip():
+        return lab.strip()
+    if isinstance(lab, dict):
+        has_field = any(
+            isinstance(lab.get(k), str) and lab[k].strip()
+            for k in ("prediction", "analysis", "advice")
+        )
+        if has_field:
+            return lab
+    return None
+
+
+def main(inp: pathlib.Path, out: pathlib.Path) -> None:
+    stats = Counter()
+    good = []
+    for raw in inp.read_text(encoding="utf-8").splitlines():
+        if not raw.strip():
+            stats["empty"] += 1
+            continue
+        try:
+            rec = json.loads(raw)
+        except json.JSONDecodeError:
+            stats["bad_json"] += 1
+            continue
+        prompt = rec.get("prompt", "").strip()
+        label = normalize_label(rec.get("label"))
+        if prompt and label is not None:
+            good.append(json.dumps({"prompt": prompt, "label": label}, ensure_ascii=False))
+            stats["kept"] += 1
+        else:
+            stats["bad_schema"] += 1
+    out.write_text("\n".join(good) + ("\n" if good else ""), encoding="utf-8")
+    print(f"[clean_jsonl] wrote {stats['kept']} samples → {out}")
+    if stats["bad_json"] or stats["bad_schema"]:
+        print("[clean_jsonl] discarded:")
+        for k in ("empty", "bad_json", "bad_schema"):
+            if stats[k]:
+                print(f"  {k}: {stats[k]}")
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("input", type=pathlib.Path)
+    p.add_argument("-o", "--output", type=pathlib.Path, help="cleaned file path")
+    args = p.parse_args()
+    inp = args.input.resolve()
+    out = args.output or inp.with_name(f"cleaned_{inp.name}")
+    main(inp, out)

--- a/test8/data_loader.py
+++ b/test8/data_loader.py
@@ -1,0 +1,120 @@
+import datetime
+from pathlib import Path
+from typing import Dict, Sequence
+
+import pandas as pd
+import requests
+
+
+class EastMoneyAPI:
+    """Wrapper around the EastMoney K-line API with optional local caching.
+
+    Parameters
+    ----------
+    cache_dir: str or Path, optional
+        Directory to store cached csv files. Defaults to ``test8/cache``.
+    use_cache: bool
+        Whether to read/write cache files. Defaults to ``True``.
+    """
+
+    KLINE_URL = "https://push2his.eastmoney.com/api/qt/stock/kline/get"
+
+    def __init__(self, cache_dir: str | Path | None = None, use_cache: bool = True) -> None:
+        self.session = requests.Session()
+        self.use_cache = use_cache
+        self.cache_dir = Path(cache_dir or Path(__file__).with_name("cache"))
+        if self.use_cache:
+            self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    def _secid(self, code: str) -> str:
+        return f"{'1' if code.startswith('6') else '0'}.{code}"
+
+    def _cache_file(self, code: str, klt: int, num: int) -> Path:
+        return self.cache_dir / f"{code}_{klt}_{num}.csv"
+
+    # ------------------------------------------------------------------
+    def get_kline_data(
+        self, stock_code: str, *, klt: int = 101, num: int = 1000, refresh: bool = False
+    ) -> pd.DataFrame | None:
+        """Fetch kline data for ``stock_code``.
+
+        Data are cached locally so subsequent calls with the same arguments can
+        run offline. When ``refresh`` is True a new network request is forced.
+        """
+
+        cache_path = self._cache_file(stock_code, klt, num)
+        if self.use_cache and cache_path.exists() and not refresh:
+            try:
+                return pd.read_csv(cache_path)
+            except Exception:
+                pass  # Fall back to network fetch
+
+        params = {
+            "secid": self._secid(stock_code),
+            "klt": klt,
+            "fqt": 0,
+            "lmt": num,
+            "end": "20500000",
+            "beg": "0",
+            "fields1": "f1,f2,f3,f4,f5,f6",
+            "fields2": "f51,f52,f53,f54,f55,f56,f57,f58",
+        }
+        try:
+            r = self.session.get(self.KLINE_URL, params=params, timeout=8)
+            r.raise_for_status()
+            js = r.json()
+            klines = js.get("data", {}).get("klines", [])
+            records = []
+            for line in klines:
+                d = line.split(",")
+                records.append(
+                    {
+                        "date": d[0],
+                        "open": float(d[1]),
+                        "close": float(d[2]),
+                        "high": float(d[3]),
+                        "low": float(d[4]),
+                        "volume": float(d[5]),
+                    }
+                )
+            df = pd.DataFrame(records)
+            df.sort_values("date", inplace=True)
+            df.reset_index(drop=True, inplace=True)
+            if self.use_cache:
+                df.to_csv(cache_path, index=False)
+            return df
+        except Exception as e:  # pragma: no cover - network issues
+            if self.use_cache and cache_path.exists():
+                try:
+                    return pd.read_csv(cache_path)
+                except Exception:
+                    pass
+            print(f"[EastMoneyAPI] {stock_code} fetch failed: {e}")
+            return None
+
+
+# ----------------------------------------------------------------------
+def get_recent_data(
+    stock_codes: Sequence[str],
+    *,
+    days: int = 90,
+    klt: int = 101,
+    api: EastMoneyAPI | None = None,
+) -> Dict[str, pd.DataFrame]:
+    """Download recent kline data for ``stock_codes``.
+
+    The returned dict maps each stock code to a :class:`pandas.DataFrame` with
+    at most ``days`` of records. Data are cached locally via ``EastMoneyAPI``.
+    """
+
+    api = api or EastMoneyAPI()
+    today = datetime.date.today()
+    start_date = today - datetime.timedelta(days=days + 10)
+    out: Dict[str, pd.DataFrame] = {}
+    for code in stock_codes:
+        df = api.get_kline_data(code, klt=klt, num=1000)
+        if df is not None:
+            df = df[df["date"] >= start_date.strftime("%Y-%m-%d")].reset_index(drop=True)
+            out[code] = df
+    return out

--- a/test8/dataset_builder.py
+++ b/test8/dataset_builder.py
@@ -1,0 +1,149 @@
+"""Utilities for building stock K-line datasets with technical indicators."""
+
+from __future__ import annotations
+
+import json
+import random
+from pathlib import Path
+from typing import Any, Iterable, Sequence, Tuple
+
+try:
+    from .config import STOCK_CODES as DEFAULT_CODES
+except Exception:  # pragma: no cover - optional
+    DEFAULT_CODES = ["600000"]
+
+from .data_loader import EastMoneyAPI
+
+
+# ---------------------------------------------------------------------------
+def _fetch_kline(code: str, days: int, api: EastMoneyAPI) -> Any:
+    df = api.get_kline_data(code, num=days)
+    if df is None:
+        return None
+    return df.tail(days).reset_index(drop=True)
+
+
+def _compute_indicators(df) -> None:
+    """Add MA5/MA10, RSI14 and MACD columns to ``df`` in-place."""
+    import numpy as np
+    df["pct_chg"] = df["close"].pct_change() * 100
+    df["pct_chg"].fillna(0, inplace=True)
+    df["MA5"] = df["close"].rolling(5).mean()
+    df["MA10"] = df["close"].rolling(10).mean()
+    diffs = df["close"].diff()
+    gains = diffs.clip(lower=0)
+    losses = -diffs.clip(upper=0)
+    avg_gain = gains.ewm(alpha=1 / 14, adjust=False).mean()
+    avg_loss = losses.ewm(alpha=1 / 14, adjust=False).mean()
+    rs = avg_gain / avg_loss
+    rs_values = rs.to_numpy()
+    avg_gain_values = avg_gain.to_numpy()
+    avg_loss_values = avg_loss.to_numpy()
+    rsi = np.where(
+        avg_loss_values == 0,
+        np.where(avg_gain_values == 0, 50, 100),
+        100 - 100 / (1 + rs_values),
+    )
+    df["RSI14"] = rsi
+    ema12 = df["close"].ewm(span=12, adjust=False).mean()
+    ema26 = df["close"].ewm(span=26, adjust=False).mean()
+    df["MACD"] = ema12 - ema26
+    df[["MA5", "MA10", "RSI14", "MACD"]] = df[["MA5", "MA10", "RSI14", "MACD"]].round(2)
+
+
+def _window_samples(df, window: int) -> Iterable[Any]:
+    n = len(df)
+    for i in range(n - window + 1):
+        if (
+            df["volume"].iloc[i : i + window].eq(0).any()
+            or df["pct_chg"].iloc[i : i + window].abs().gt(20).any()
+        ):
+            continue
+        yield df.iloc[i : i + window].reset_index(drop=True)
+
+
+def _make_sample(window, code: str) -> dict[str, Any]:
+    change = ((window["close"].iloc[-1] / window["close"].iloc[0]) - 1) * 100
+    trend = "up" if change > 3 else "down" if change < -3 else "stable"
+    summary = window[
+        [
+            "date",
+            "open",
+            "close",
+            "high",
+            "low",
+            "volume",
+            "MA5",
+            "MA10",
+            "RSI14",
+            "MACD",
+        ]
+    ].to_dict(orient="records")
+    return {
+        "stock_code": code,
+        "change": round(change, 2),
+        "trend": trend,
+        "prediction": "",
+        "analysis": "",
+        "advice": "",
+        "kline_summary": summary,
+    }
+
+
+def format_prompt(sample: dict[str, Any]) -> str:
+    summary = json.dumps(sample["kline_summary"], ensure_ascii=False)
+    return (
+        f"股票 {sample['stock_code']} 近{len(sample['kline_summary'])}日K线数据: {summary}\n"
+        f"涨跌幅: {sample['change']}%。请预测后市走势，给出简短分析和操作建议，"
+        "并以 JSON 格式回复，包括 'prediction', 'analysis', 'advice' 三个字段。"
+    )
+
+
+# ---------------------------------------------------------------------------
+def _save_jsonl(samples: Iterable[dict[str, Any]], path: Path) -> None:
+    with path.open("w", encoding="utf-8") as f:
+        for s in samples:
+            f.write(json.dumps(s, ensure_ascii=False) + "\n")
+
+
+def build_dataset(
+    stock_codes: Sequence[str] | None = None,
+    *,
+    days: int = 180,
+    window: int = 30,
+    val_ratio: float = 0.2,
+    seed: int | None = None,
+    out_dir: str | Path | None = None,
+) -> Tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Build dataset and optionally save to JSONL files.
+
+    Returns ``(train_samples, val_samples)``.
+    """
+
+    codes = list(stock_codes) if stock_codes else list(DEFAULT_CODES)
+    rng = random.Random(seed)
+    api = EastMoneyAPI()
+    samples: list[dict[str, Any]] = []
+
+    for code in codes:
+        df = _fetch_kline(code, days, api)
+        if df is None or df.empty:
+            continue
+        _compute_indicators(df)
+        if len(df) < window:
+            continue
+        for win in _window_samples(df, window):
+            sample = _make_sample(win, code)
+            samples.append(sample)
+
+    rng.shuffle(samples)
+    split = int(len(samples) * (1 - val_ratio))
+    train, val = samples[:split], samples[split:]
+
+    if out_dir:
+        out_path = Path(out_dir)
+        out_path.mkdir(parents=True, exist_ok=True)
+        _save_jsonl(train, out_path / "train.jsonl")
+        _save_jsonl(val, out_path / "val.jsonl")
+
+    return train, val

--- a/test8/teacher_labeler.py
+++ b/test8/teacher_labeler.py
@@ -1,0 +1,77 @@
+"""Automatic labeling of dataset samples using a teacher model or API."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Iterable
+
+from .dataset_builder import format_prompt
+
+
+def call_teacher(prompt: str) -> dict[str, str]:
+    """Call external teacher model if ``ARK_API_KEY`` is set.
+
+    When no API key is found or a request fails, a fallback empty response is
+    returned so the rest of the pipeline can continue offline.
+    """
+
+    api_key = os.getenv("ARK_API_KEY", "")
+    if not api_key:
+        return {"content": "{}", "reasoning": ""}
+    try:  # pragma: no cover - network
+        from volcenginesdkarkruntime import Ark
+
+        client = Ark(api_key=api_key)
+        resp = client.chat.completions.create(
+            model="deepseek-r1-250528",
+            messages=[{"role": "user", "content": prompt}],
+        )
+        msg = resp.choices[0].message
+        content = msg.content.strip()
+        reasoning = getattr(msg, "reasoning_content", "").strip()
+        return {"content": content, "reasoning": reasoning}
+    except Exception as e:
+        return {"content": f"{{}}", "reasoning": f"[error: {e}]"}
+
+
+def label_dataset(samples: Iterable[dict], out_dir: str | Path = ".") -> None:
+    """Label ``samples`` and write multitask JSONL files.
+
+    Three files are produced in ``out_dir``:
+    ``train_trend.jsonl`` for prediction labels,
+    ``train_advice.jsonl`` for advice generation and
+    ``train_explain.jsonl`` for analysis/description tasks.
+    """
+
+    out_path = Path(out_dir)
+    out_path.mkdir(parents=True, exist_ok=True)
+    trend_f = (out_path / "train_trend.jsonl").open("w", encoding="utf-8")
+    advice_f = (out_path / "train_advice.jsonl").open("w", encoding="utf-8")
+    explain_f = (out_path / "train_explain.jsonl").open("w", encoding="utf-8")
+
+    for sample in samples:
+        prompt = format_prompt(sample)
+        ans = call_teacher(prompt)
+        try:
+            data = json.loads(ans.get("content", "{}"))
+        except json.JSONDecodeError:
+            data = {}
+        # Fallback for trend if teacher doesn't provide one
+        if not data.get("prediction"):
+            change = sample.get("change", 0)
+            if change > 3:
+                data["prediction"] = "up"
+            elif change < -3:
+                data["prediction"] = "down"
+            else:
+                data["prediction"] = "stable"
+        trend_f.write(json.dumps({"prompt": prompt, "label": data.get("prediction", "")}, ensure_ascii=False) + "\n")
+        advice_f.write(json.dumps({"prompt": prompt, "label": data.get("advice", "")}, ensure_ascii=False) + "\n")
+        explain_label = data.get("analysis") or ans.get("reasoning", "")
+        explain_f.write(json.dumps({"prompt": prompt, "label": explain_label}, ensure_ascii=False) + "\n")
+
+    trend_f.close()
+    advice_f.close()
+    explain_f.close()


### PR DESCRIPTION
## Summary
- implement EastMoney API wrapper with optional caching and recent data helper
- build K-line dataset with technical indicators and JSONL export
- add teacher labeling, sample cleaning scripts, and test path helpers

## Testing
- `PYTHONPATH=$PWD pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad16496178832b84bf929e3e002f91