### PR TITLE
Add pipeline script for test8

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,3 +319,14 @@ python -m test6.evaluate --questions question.jsonl --models-dir multi_lora
 
 
 
+
+## test8：一键运行全流程脚本
+
+`test8` 目录下提供了 `run_all.sh`，依次执行数据构建、教师标注、三类任务模型训练、模型合并以及最终评测。
+运行该脚本即可完成蒸馏训练到评估的完整流程：
+
+```bash
+bash test8/run_all.sh
+```
+
+脚本使用 `test8/models` 中的本地基础模型权重，并在 `test8/` 下生成所需的数据与日志。

--- a/test8/run_all.sh
+++ b/test8/run_all.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(dirname "$SCRIPT_DIR")"
+
+# directories for data, labels, models, logs
+DATA_DIR="$SCRIPT_DIR/data/processed"
+LABEL_DIR="$SCRIPT_DIR/data/labeled"
+MODEL_DIR="$SCRIPT_DIR/models"
+LOG_DIR="$SCRIPT_DIR/logs"
+BASE_MODEL="$MODEL_DIR/base_model"  # local base model path
+
+mkdir -p "$DATA_DIR" "$LABEL_DIR" "$MODEL_DIR" "$LOG_DIR"
+
+cd "$REPO_DIR"
+
+# 1. Build dataset
+python -m test8.dataset_builder --out-dir "$DATA_DIR"
+
+# 2. Teacher labeling
+python -m test8.teacher_labeler --data "$DATA_DIR/train.jsonl" --out-dir "$LABEL_DIR"
+
+# 3. Train models
+python -m test8.train_trend_model --train "$LABEL_DIR/train_trend.jsonl" --model-out "$MODEL_DIR/trend" --log-dir "$LOG_DIR/trend" --base-model "$BASE_MODEL"
+python -m test8.train_advice_model --train "$LABEL_DIR/train_advice.jsonl" --model-out "$MODEL_DIR/advice" --log-dir "$LOG_DIR/advice" --base-model "$BASE_MODEL"
+python -m test8.train_explanation_model --train "$LABEL_DIR/train_explain.jsonl" --model-out "$MODEL_DIR/explain" --log-dir "$LOG_DIR/explain" --base-model "$BASE_MODEL"
+
+# 4. Merge models
+bash "$SCRIPT_DIR/merge_models.sh" "$MODEL_DIR" "$MODEL_DIR/merged"
+
+# 5. Evaluate merged model
+python -m test8.evaluate_models --data "$DATA_DIR/val.jsonl" --model "$MODEL_DIR/merged" --log-dir "$LOG_DIR"


### PR DESCRIPTION
## Summary
- add run_all.sh to orchestrate dataset building, teacher labeling, model training, merging and evaluation
- document pipeline script usage in README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_68ad18041ee4832b870dd189bdb31a3d