### PR TITLE
feat: add mergekit config and merge script for test8

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,3 +330,10 @@ bash test8/run_all.sh
 ```
 
 脚本使用 `test8/models` 中的本地基础模型权重，并在 `test8/` 下生成所需的数据与日志。
+在执行模型合并前需预先安装 [Aratako/mergekit-qwen2](https://github.com/Aratako/mergekit-qwen2)，例如：
+
+```bash
+pip install git+https://github.com/Aratako/mergekit-qwen2.git
+```
+
+所有模型权重均从本地路径加载，不会触发网络下载。

--- a/test8/scripts/merge_models.sh
+++ b/test8/scripts/merge_models.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+BASE_DIR=$(dirname "$SCRIPT_DIR")
+OUTPUT_DIR="$BASE_DIR/models/merged_model"
+
+mkdir -p "$OUTPUT_DIR"
+cd "$BASE_DIR"
+
+mergekit-moe-qwen2 scripts/merge_models_config.yml "$OUTPUT_DIR" --allow-crimes
+
+cp "$SCRIPT_DIR/configuration_qwen2.py" "$OUTPUT_DIR/"
+cp "$SCRIPT_DIR/modeling_qwen2.py" "$OUTPUT_DIR/"

--- a/test8/scripts/merge_models_config.yml
+++ b/test8/scripts/merge_models_config.yml
@@ -1,0 +1,13 @@
+base_model: ./models/Qwen2.5-7B
+dtype: float16
+shared_experts: 2
+experts:
+  - source_model: ./models/advice_model
+    positive_prompts:
+      - "给出股票操作建议"
+  - source_model: ./models/explanation_model
+    positive_prompts:
+      - "用通俗语言解释财报"
+  - source_model: ./models/trend_model
+    positive_prompts:
+      - "预测市场趋势"


### PR DESCRIPTION
## Summary
- add merge_models_config.yml with base model and three expert models
- add merge_models.sh to merge experts and copy MoE helpers
- document mergekit-qwen2 installation and local model loading in README

## Testing
- `pytest` (fails: ModuleNotFoundError: No module named 'src')

------
https://chatgpt.com/codex/tasks/task_e_68ad1ad50d48832b82ceae81695ec00f