### PR TITLE
Add tests and documentation for test8 module

### DIFF
--- a/test8/README.md
+++ b/test8/README.md
@@ -1,0 +1,49 @@
+# test8 Module
+
+This module demonstrates a lightweight pipeline for building stock K-line datasets and training small language models to predict stock trends, provide investment advice and explain reasoning.
+
+## Directory Structure
+
+```
+ test8/
+ ├── config.py            # configuration of paths and hyper parameters
+ ├── dataset_builder.py   # utilities for creating JSONL training data
+ ├── data_loader.py       # wrapper around EastMoney K-line API
+ ├── scripts/             # training and evaluation scripts
+ ├── models/              # model checkpoints (created after training)
+ └── run_all.sh           # example one-click command
+```
+
+## Dependencies
+
+- Python >= 3.10
+- pandas
+- requests
+- torch
+- transformers
+
+Install them with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Data Format
+
+Each line in the training data is a JSON object:
+
+```json
+{
+  "instruction": "Predict future trend",
+  "input": "<kline summary>",
+  "output": "trend/analysis/advice"
+}
+```
+
+## One-click Command
+
+Run the complete workflow (dataset building and model training) with:
+
+```bash
+bash run_all.sh
+```

--- a/test8/tests/test_dataset_builder.py
+++ b/test8/tests/test_dataset_builder.py
@@ -1,0 +1,86 @@
+import sys
+from pathlib import Path
+from collections import Counter
+
+import pandas as pd
+
+# Allow imports from repo root
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from test8 import dataset_builder as db
+
+
+def test_build_dataset_format_and_balance(monkeypatch):
+    # prepare three windows producing up, down and stable trends
+    window_up = pd.DataFrame(
+        {
+            "date": ["d1", "d2"],
+            "open": [100, 102],
+            "close": [100, 104],
+            "high": [101, 105],
+            "low": [99, 103],
+            "volume": [1000, 1000],
+            "MA5": [0, 0],
+            "MA10": [0, 0],
+            "RSI14": [0, 0],
+            "MACD": [0, 0],
+        }
+    )
+    window_down = pd.DataFrame(
+        {
+            "date": ["d1", "d2"],
+            "open": [100, 98],
+            "close": [100, 95],
+            "high": [101, 99],
+            "low": [99, 94],
+            "volume": [1000, 1000],
+            "MA5": [0, 0],
+            "MA10": [0, 0],
+            "RSI14": [0, 0],
+            "MACD": [0, 0],
+        }
+    )
+    window_stable = pd.DataFrame(
+        {
+            "date": ["d1", "d2"],
+            "open": [100, 101],
+            "close": [100, 101],
+            "high": [101, 102],
+            "low": [99, 100],
+            "volume": [1000, 1000],
+            "MA5": [0, 0],
+            "MA10": [0, 0],
+            "RSI14": [0, 0],
+            "MACD": [0, 0],
+        }
+    )
+    windows = [window_up, window_down, window_stable]
+
+    def fake_fetch(code, days, api):
+        # ensure len(df) >= window inside build_dataset
+        return pd.DataFrame({"close": [1, 2]})
+
+    def fake_window_samples(df, window):
+        for w in windows:
+            yield w
+
+    monkeypatch.setattr(db, "_fetch_kline", fake_fetch)
+    monkeypatch.setattr(db, "_compute_indicators", lambda df: None)
+    monkeypatch.setattr(db, "_window_samples", fake_window_samples)
+
+    train, val = db.build_dataset(["000001"], days=2, window=2, val_ratio=0, seed=0)
+
+    assert val == []
+    assert len(train) == 3
+    sample = train[0]
+    assert set(sample.keys()) == {
+        "stock_code",
+        "change",
+        "trend",
+        "prediction",
+        "analysis",
+        "advice",
+        "kline_summary",
+    }
+    counts = Counter(s["trend"] for s in train)
+    assert counts["up"] == counts["down"] == counts["stable"] == 1

--- a/test8/tests/test_training_scripts.py
+++ b/test8/tests/test_training_scripts.py
@@ -1,0 +1,109 @@
+import sys
+from pathlib import Path
+import json
+import argparse
+import importlib
+
+# Allow imports from repo root
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+
+
+def _dummy_tokenizer_cls():
+    class DummyTokenizer:
+        eos_token = "<eos>"
+        pad_token = None
+        pad_token_id = 0
+
+        @classmethod
+        def from_pretrained(cls, name, trust_remote_code=True):
+            return cls()
+
+        def __call__(self, text, add_special_tokens=False, truncation=True, max_length=None):
+            return type("Tokens", (), {"input_ids": [1]})
+
+        def save_pretrained(self, path):
+            Path(path).mkdir(parents=True, exist_ok=True)
+
+    return DummyTokenizer
+
+
+def _dummy_model_cls():
+    class DummyModel:
+        config = type("Cfg", (), {"use_cache": False})
+
+        @classmethod
+        def from_pretrained(cls, name, trust_remote_code=True, device_map=None, load_in_8bit=False):
+            return cls()
+
+        def save_pretrained(self, path):
+            Path(path).mkdir(parents=True, exist_ok=True)
+
+    return DummyModel
+
+
+def _dummy_trainer_cls():
+    class DummyTrainer:
+        def __init__(self, model, args, train_dataset, data_collator):
+            pass
+
+        def train(self):
+            pass
+
+        def save_model(self, path):
+            Path(path).mkdir(parents=True, exist_ok=True)
+
+    return DummyTrainer
+
+
+# ---------------------------------------------------------------------------
+
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "mod_name,data_file,path_attr",
+    [
+        ("test8.scripts.train_trend_model", "train_trend.jsonl", "TREND_MODEL_PATH"),
+        ("test8.scripts.train_advice_model", "train_advice.jsonl", "ADVICE_MODEL_PATH"),
+        (
+            "test8.scripts.train_explanation_model",
+            "train_explanation.jsonl",
+            "EXPLANATION_MODEL_PATH",
+        ),
+    ],
+)
+def test_training_scripts_load(monkeypatch, tmp_path, mod_name, data_file, path_attr):
+    mod = importlib.import_module(mod_name)
+    data_path = tmp_path / data_file
+    data_path.write_text(
+        json.dumps({"instruction": "hi", "input": "", "output": "bye"}) + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(mod, "DATA_DIR", tmp_path)
+    monkeypatch.setattr(mod, "BASE_MODEL_PATH", "dummy-model")
+    monkeypatch.setattr(mod, path_attr, tmp_path / "out")
+
+    monkeypatch.setattr(mod, "AutoTokenizer", _dummy_tokenizer_cls())
+    monkeypatch.setattr(mod, "AutoModelForCausalLM", _dummy_model_cls())
+    monkeypatch.setattr(mod, "Trainer", _dummy_trainer_cls())
+    monkeypatch.setattr(mod, "collate_fn", lambda batch, pad_token_id: {})
+    monkeypatch.setattr(
+        mod,
+        "parse_args",
+        lambda: argparse.Namespace(
+            epochs=1,
+            learning_rate=0.0,
+            batch_size=1,
+            gradient_accumulation_steps=1,
+            use_lora=False,
+            lora_r=0,
+            lora_alpha=0,
+            lora_dropout=0.0,
+            use_8bit=False,
+        ),
+    )
+
+    mod.main()


### PR DESCRIPTION
## Summary
- add tests validating dataset builder output and class balance
- add smoke tests ensuring training scripts load dummy models and data
- document test8 module structure, dependencies, and usage

## Testing
- `PYTHONPATH=$PWD pytest test8/tests/test_dataset_builder.py test8/tests/test_training_scripts.py tests/test_dataset.py tests/test_inference_external.py tests/test_workflow.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad27195ac4832b82f859cd4cff681c