### PR TITLE
Add path flags and modular training entry points

### DIFF
--- a/test8/run_all.sh
+++ b/test8/run_all.sh
@@ -5,10 +5,10 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(dirname "$SCRIPT_DIR")"
 
 # directories for data, labels, models, logs
-DATA_DIR="$SCRIPT_DIR/data/processed"
-LABEL_DIR="$SCRIPT_DIR/data/labeled"
-MODEL_DIR="$SCRIPT_DIR/models"
-LOG_DIR="$SCRIPT_DIR/logs"
+DATA_DIR="$REPO_DIR/data"
+LABEL_DIR="$DATA_DIR/labeled"
+MODEL_DIR="$REPO_DIR/models"
+LOG_DIR="$REPO_DIR/logs"
 BASE_MODEL="$MODEL_DIR/base_model"  # local base model path
 
 mkdir -p "$DATA_DIR" "$LABEL_DIR" "$MODEL_DIR" "$LOG_DIR"
@@ -16,18 +16,29 @@ mkdir -p "$DATA_DIR" "$LABEL_DIR" "$MODEL_DIR" "$LOG_DIR"
 cd "$REPO_DIR"
 
 # 1. Build dataset
-python -m test8.dataset_builder --out-dir "$DATA_DIR"
+python - <<PY
+from test8.dataset_builder import build_dataset
+build_dataset(out_dir="$DATA_DIR")
+PY
 
 # 2. Teacher labeling
-python -m test8.teacher_labeler --data "$DATA_DIR/train.jsonl" --out-dir "$LABEL_DIR"
+python - <<PY
+import json
+from pathlib import Path
+from test8.teacher_labeler import label_dataset
+
+data_path = Path("$DATA_DIR/train.jsonl")
+samples = [json.loads(line) for line in data_path.open("r", encoding="utf-8")]
+label_dataset(samples, out_dir="$LABEL_DIR")
+PY
 
 # 3. Train models
-python -m test8.train_trend_model --train "$LABEL_DIR/train_trend.jsonl" --model-out "$MODEL_DIR/trend" --log-dir "$LOG_DIR/trend" --base-model "$BASE_MODEL"
-python -m test8.train_advice_model --train "$LABEL_DIR/train_advice.jsonl" --model-out "$MODEL_DIR/advice" --log-dir "$LOG_DIR/advice" --base-model "$BASE_MODEL"
-python -m test8.train_explanation_model --train "$LABEL_DIR/train_explain.jsonl" --model-out "$MODEL_DIR/explain" --log-dir "$LOG_DIR/explain" --base-model "$BASE_MODEL"
+python -m test8.scripts.train_trend_model --train "$LABEL_DIR/train_trend.jsonl" --model-out "$MODEL_DIR/trend" --log-dir "$LOG_DIR/trend" --base-model "$BASE_MODEL"
+python -m test8.scripts.train_advice_model --train "$LABEL_DIR/train_advice.jsonl" --model-out "$MODEL_DIR/advice" --log-dir "$LOG_DIR/advice" --base-model "$BASE_MODEL"
+python -m test8.scripts.train_explanation_model --train "$LABEL_DIR/train_explain.jsonl" --model-out "$MODEL_DIR/explain" --log-dir "$LOG_DIR/explain" --base-model "$BASE_MODEL"
 
 # 4. Merge models
 bash "$SCRIPT_DIR/merge_models.sh" "$MODEL_DIR" "$MODEL_DIR/merged"
 
 # 5. Evaluate merged model
-python -m test8.evaluate_models --data "$DATA_DIR/val.jsonl" --model "$MODEL_DIR/merged" --log-dir "$LOG_DIR"
+python -m test8.scripts.evaluate_models --data "$DATA_DIR/val.jsonl" --model "$MODEL_DIR/merged" --log-dir "$LOG_DIR"

--- a/test8/scripts/train_advice_model.py
+++ b/test8/scripts/train_advice_model.py
@@ -92,6 +92,30 @@ def collate_fn(batch, pad_token_id: int):
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Train advice model")
+    parser.add_argument(
+        "--train",
+        type=Path,
+        default=DATA_DIR / "train_advice.jsonl",
+        help="Path to training data",
+    )
+    parser.add_argument(
+        "--model-out",
+        type=Path,
+        default=ADVICE_MODEL_PATH,
+        help="Where to store the trained model",
+    )
+    parser.add_argument(
+        "--log-dir",
+        type=Path,
+        default=None,
+        help="Optional directory for training logs",
+    )
+    parser.add_argument(
+        "--base-model",
+        type=str,
+        default=str(BASE_MODEL_PATH),
+        help="Base model identifier or path",
+    )
     parser.add_argument("--epochs", type=int, default=EPOCHS)
     parser.add_argument("--learning_rate", type=float, default=LEARNING_RATE)
     parser.add_argument("--batch_size", type=int, default=BATCH_SIZE)
@@ -108,9 +132,10 @@ def parse_args():
 
 def main():
     args = parse_args()
-    model_path = BASE_MODEL_PATH
-    data_path = DATA_DIR / "train_advice.jsonl"
-    output_path = ADVICE_MODEL_PATH
+    model_path = getattr(args, "base_model", str(BASE_MODEL_PATH))
+    data_path = Path(getattr(args, "train", DATA_DIR / "train_advice.jsonl"))
+    output_path = Path(getattr(args, "model_out", ADVICE_MODEL_PATH))
+    log_dir = getattr(args, "log_dir", None)
 
     tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
     if tokenizer.pad_token is None:
@@ -145,6 +170,7 @@ def main():
         fp16=True,
         logging_steps=10,
         save_strategy="epoch",
+        logging_dir=str(log_dir) if log_dir else None,
     )
 
     trainer = Trainer(

--- a/test8/scripts/train_explanation_model.py
+++ b/test8/scripts/train_explanation_model.py
@@ -92,6 +92,30 @@ def collate_fn(batch, pad_token_id: int):
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Train explanation model")
+    parser.add_argument(
+        "--train",
+        type=Path,
+        default=DATA_DIR / "train_explain.jsonl",
+        help="Path to training data",
+    )
+    parser.add_argument(
+        "--model-out",
+        type=Path,
+        default=EXPLANATION_MODEL_PATH,
+        help="Where to store the trained model",
+    )
+    parser.add_argument(
+        "--log-dir",
+        type=Path,
+        default=None,
+        help="Optional directory for training logs",
+    )
+    parser.add_argument(
+        "--base-model",
+        type=str,
+        default=str(BASE_MODEL_PATH),
+        help="Base model identifier or path",
+    )
     parser.add_argument("--epochs", type=int, default=EPOCHS)
     parser.add_argument("--learning_rate", type=float, default=LEARNING_RATE)
     parser.add_argument("--batch_size", type=int, default=BATCH_SIZE)
@@ -108,9 +132,10 @@ def parse_args():
 
 def main():
     args = parse_args()
-    model_path = BASE_MODEL_PATH
-    data_path = DATA_DIR / "train_explanation.jsonl"
-    output_path = EXPLANATION_MODEL_PATH
+    model_path = getattr(args, "base_model", str(BASE_MODEL_PATH))
+    data_path = Path(getattr(args, "train", DATA_DIR / "train_explain.jsonl"))
+    output_path = Path(getattr(args, "model_out", EXPLANATION_MODEL_PATH))
+    log_dir = getattr(args, "log_dir", None)
 
     tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
     if tokenizer.pad_token is None:
@@ -145,6 +170,7 @@ def main():
         fp16=True,
         logging_steps=10,
         save_strategy="epoch",
+        logging_dir=str(log_dir) if log_dir else None,
     )
 
     trainer = Trainer(


### PR DESCRIPTION
## Summary
- add CLI arguments to training scripts for data, model output, logs and base model paths
- ensure run_all.sh uses module invocations and consistent data/model directories

## Testing
- `pytest test8/tests/test_training_scripts.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_68ad2a599da8832bbfc25000df37e41b