### PR TITLE
Use prompt/label schema in training scripts

### DIFF
--- a/test8/README.md
+++ b/test8/README.md
@@ -30,13 +30,13 @@ pip install -r requirements.txt
 
 ## Data Format
 
-Each line in the training data is a JSON object:
+Each line in the training data is a JSON object with the keys used by the
+training scripts:
 
 ```json
 {
-  "instruction": "Predict future trend",
-  "input": "<kline summary>",
-  "output": "trend/analysis/advice"
+  "prompt": "<model input>",
+  "label": "expected output"
 }
 ```
 

--- a/test8/scripts/train_advice_model.py
+++ b/test8/scripts/train_advice_model.py
@@ -50,14 +50,10 @@ class SFTDataset(Dataset):
 
     def __getitem__(self, idx):
         example = self.samples[idx]
-        instruction = example.get("instruction", "")
-        input_text = example.get("input", "")
-        output = example.get("output", "")
-
-        if input_text:
-            prompt = f"{instruction}\n{input_text}"
-        else:
-            prompt = instruction
+        prompt = example.get("prompt", "")
+        output = example.get("label", "")
+        if isinstance(output, dict):
+            output = output.get("raw") or json.dumps(output, ensure_ascii=False)
 
         prompt_ids = self.tokenizer(
             prompt, add_special_tokens=False, truncation=True, max_length=self.max_length

--- a/test8/scripts/train_explanation_model.py
+++ b/test8/scripts/train_explanation_model.py
@@ -50,14 +50,10 @@ class SFTDataset(Dataset):
 
     def __getitem__(self, idx):
         example = self.samples[idx]
-        instruction = example.get("instruction", "")
-        input_text = example.get("input", "")
-        output = example.get("output", "")
-
-        if input_text:
-            prompt = f"{instruction}\n{input_text}"
-        else:
-            prompt = instruction
+        prompt = example.get("prompt", "")
+        output = example.get("label", "")
+        if isinstance(output, dict):
+            output = output.get("raw") or json.dumps(output, ensure_ascii=False)
 
         prompt_ids = self.tokenizer(
             prompt, add_special_tokens=False, truncation=True, max_length=self.max_length

--- a/test8/scripts/train_trend_model.py
+++ b/test8/scripts/train_trend_model.py
@@ -50,14 +50,10 @@ class SFTDataset(Dataset):
 
     def __getitem__(self, idx):
         example = self.samples[idx]
-        instruction = example.get("instruction", "")
-        input_text = example.get("input", "")
-        output = example.get("output", "")
-
-        if input_text:
-            prompt = f"{instruction}\n{input_text}"
-        else:
-            prompt = instruction
+        prompt = example.get("prompt", "")
+        output = example.get("label", "")
+        if isinstance(output, dict):
+            output = output.get("raw") or json.dumps(output, ensure_ascii=False)
 
         prompt_ids = self.tokenizer(
             prompt, add_special_tokens=False, truncation=True, max_length=self.max_length

--- a/test8/tests/test_training_scripts.py
+++ b/test8/tests/test_training_scripts.py
@@ -69,7 +69,7 @@ import pytest
         ("test8.scripts.train_advice_model", "train_advice.jsonl", "ADVICE_MODEL_PATH"),
         (
             "test8.scripts.train_explanation_model",
-            "train_explanation.jsonl",
+            "train_explain.jsonl",
             "EXPLANATION_MODEL_PATH",
         ),
     ],
@@ -78,7 +78,7 @@ def test_training_scripts_load(monkeypatch, tmp_path, mod_name, data_file, path_
     mod = importlib.import_module(mod_name)
     data_path = tmp_path / data_file
     data_path.write_text(
-        json.dumps({"instruction": "hi", "input": "", "output": "bye"}) + "\n",
+        json.dumps({"prompt": "hi", "label": "bye"}) + "\n",
         encoding="utf-8",
     )
 


### PR DESCRIPTION
## Summary
- Update SFTDataset in training scripts to read `prompt` and `label` fields and handle dictionary labels
- Adjust unit tests to use the new data schema and correct explanation file name
- Document the `prompt`/`label` format in the module README

## Testing
- `pytest` *(fails: No module named 'src' in test7 tests)*
- `pytest test8/tests/test_training_scripts.py`

------
https://chatgpt.com/codex/tasks/task_e_68ad4df1d3d0832b910f5ea3418f4a81