### PR TITLE
Align merged model path across config and scripts

### DIFF
--- a/test8/config.py
+++ b/test8/config.py
@@ -7,7 +7,7 @@ BASE_MODEL_PATH = Path("./models/Qwen2.5-7B")
 TREND_MODEL_PATH = Path("./models/trend_model")
 ADVICE_MODEL_PATH = Path("./models/advice_model")
 EXPLANATION_MODEL_PATH = Path("./models/explanation_model")
-MERGED_MODEL_PATH = Path("./models/MergedModel_7B")
+MERGED_MODEL_PATH = Path("./models/merged_model")
 
 # Data directory
 DATA_DIR = Path("./data")

--- a/test8/scripts/evaluate_models.py
+++ b/test8/scripts/evaluate_models.py
@@ -100,7 +100,7 @@ def main() -> None:  # pragma: no cover - script entry point
         "TrendModel_7B": TREND_MODEL_PATH,
         "AdviceModel_7B": ADVICE_MODEL_PATH,
         "ExplanationModel_7B": EXPLANATION_MODEL_PATH,
-        "MergedModel_7B": MERGED_MODEL_PATH,
+        "MergedModel": MERGED_MODEL_PATH,
     }
 
     results: Dict[str, Dict[str, float]] = {}

--- a/test8/scripts/merge_models.sh
+++ b/test8/scripts/merge_models.sh
@@ -3,7 +3,8 @@ set -e
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 BASE_DIR=$(dirname "$SCRIPT_DIR")
-OUTPUT_DIR="$BASE_DIR/models/merged_model"
+MERGED_MODEL_DIR="merged_model"
+OUTPUT_DIR="$BASE_DIR/models/$MERGED_MODEL_DIR"
 
 mkdir -p "$OUTPUT_DIR"
 cd "$BASE_DIR"


### PR DESCRIPTION
## Summary
- Use `models/merged_model` for merged model output path in `config.py`
- Reference the same merged model directory in evaluation script
- Centralize merged model path configuration in merging script

## Testing
- `pytest test8/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad50361fc0832b814760d02af6d2ba