### PR TITLE
Switch evaluation to 'label' and update tests

### DIFF
--- a/test8/scripts/evaluate_models.py
+++ b/test8/scripts/evaluate_models.py
@@ -43,7 +43,12 @@ def evaluate_trend(
     correct = 0
     for sample in data:
         prompt = sample.get("prompt", "")
-        reference = sample.get("completion", "").strip().lower()
+        label = sample.get("label", "")
+        if isinstance(label, dict):
+            reference = (label.get("raw") or json.dumps(label, ensure_ascii=False))
+        else:
+            reference = str(label)
+        reference = reference.strip().lower()
         prediction = generate_text(model, tokenizer, prompt).strip().lower()
         if prediction == reference:
             correct += 1
@@ -63,7 +68,11 @@ def evaluate_bleu(
     references: List[List[List[str]]] = []
     for sample in data:
         prompt = sample.get("prompt", "")
-        reference = sample.get("completion", "")
+        label = sample.get("label", "")
+        if isinstance(label, dict):
+            reference = (label.get("raw") or json.dumps(label, ensure_ascii=False))
+        else:
+            reference = str(label)
         prediction = generate_text(model, tokenizer, prompt)
         predictions.append(prediction.split())
         references.append([reference.split()])

--- a/test8/tests/test_training_scripts.py
+++ b/test8/tests/test_training_scripts.py
@@ -78,7 +78,7 @@ def test_training_scripts_load(monkeypatch, tmp_path, mod_name, data_file, path_
     mod = importlib.import_module(mod_name)
     data_path = tmp_path / data_file
     data_path.write_text(
-        json.dumps({"prompt": "hi", "label": "bye"}) + "\n",
+        json.dumps({"prompt": "hi", "label": {"raw": "bye"}}) + "\n",
         encoding="utf-8",
     )
 

--- a/tests/test_inference_external.py
+++ b/tests/test_inference_external.py
@@ -69,7 +69,7 @@ def test_label_samples_writes_json(tmp_path):
 
     def dummy(prompt):
         return {
-            "content": json.dumps({"out": prompt}),
+            "content": prompt,
             "reasoning": f"why {prompt}",
         }
 
@@ -79,5 +79,5 @@ def test_label_samples_writes_json(tmp_path):
     assert out_file.exists()
     loaded = [json.loads(line) for line in out_file.read_text().splitlines()]
     assert loaded == records
-    assert records[0]["label"] == {"out": "a", "reasoning": "why a"}
-    assert records[1]["label"] == {"out": "b", "reasoning": "why b"}
+    assert records[0]["label"] == {"raw": "a", "reasoning": "why a"}
+    assert records[1]["label"] == {"raw": "b", "reasoning": "why b"}


### PR DESCRIPTION
## Summary
- Update model evaluation to read `label` fields instead of `completion` and support dict schema
- Align test training data JSONL with training schema
- Adjust labeling tests to emit and assert `label` with `raw`/`reasoning`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*
- `pytest tests test8/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad53523df8832ba445dd8f5b3b3cc8