### PR TITLE
Ensure tests include required imports

### DIFF
--- a/test8/tests/test_dataset_builder.py
+++ b/test8/tests/test_dataset_builder.py
@@ -1,4 +1,5 @@
 import sys
+import json
 from pathlib import Path
 from collections import Counter
 

--- a/test8/tests/test_training_scripts.py
+++ b/test8/tests/test_training_scripts.py
@@ -1,8 +1,8 @@
-import sys
-from pathlib import Path
-import json
 import argparse
 import importlib
+import json
+import sys
+from pathlib import Path
 
 # Allow imports from repo root
 sys.path.append(str(Path(__file__).resolve().parents[2]))


### PR DESCRIPTION
## Summary
- Add missing json import in dataset builder tests
- Reorder training script test imports for clarity

## Testing
- `pytest test8/tests/test_dataset_builder.py test8/tests/test_training_scripts.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad549e4db4832bbe927cd5e6907bf2