### PR TITLE
Add test split support and sample data for test8 module

### DIFF
--- a/test8/data/test.jsonl
+++ b/test8/data/test.jsonl
@@ -1,0 +1,1 @@
+{"stock_code": "000003", "change": 0.0, "trend": "stable", "prediction": "", "analysis": "", "advice": "", "kline_summary": []}

--- a/test8/data/test_advice.jsonl
+++ b/test8/data/test_advice.jsonl
@@ -1,0 +1,1 @@
+{"prompt": "demo prompt", "label": "hold"}

--- a/test8/data/test_explain.jsonl
+++ b/test8/data/test_explain.jsonl
@@ -1,0 +1,1 @@
+{"prompt": "demo prompt", "label": "analysis"}

--- a/test8/data/test_trend.jsonl
+++ b/test8/data/test_trend.jsonl
@@ -1,0 +1,1 @@
+{"prompt": "demo prompt", "label": "up"}

--- a/test8/data/train.jsonl
+++ b/test8/data/train.jsonl
@@ -1,0 +1,1 @@
+{"stock_code": "000001", "change": 1.2, "trend": "up", "prediction": "", "analysis": "", "advice": "", "kline_summary": []}

--- a/test8/data/val.jsonl
+++ b/test8/data/val.jsonl
@@ -1,0 +1,1 @@
+{"stock_code": "000002", "change": -1.0, "trend": "down", "prediction": "", "analysis": "", "advice": "", "kline_summary": []}

--- a/test8/run_all.sh
+++ b/test8/run_all.sh
@@ -15,10 +15,10 @@ mkdir -p "$DATA_DIR" "$LABEL_DIR" "$MODEL_DIR" "$LOG_DIR"
 
 cd "$REPO_DIR"
 
-# 1. Build dataset
+# 1. Build dataset (including a small test split)
 python - <<PY
 from test8.dataset_builder import build_dataset
-build_dataset(out_dir="$DATA_DIR")
+build_dataset(out_dir="$DATA_DIR", test_ratio=0.1)
 PY
 
 # 2. Teacher labeling
@@ -27,9 +27,13 @@ import json
 from pathlib import Path
 from test8.teacher_labeler import label_dataset
 
-data_path = Path("$DATA_DIR/train.jsonl")
-samples = [json.loads(line) for line in data_path.open("r", encoding="utf-8")]
-label_dataset(samples, out_dir="$LABEL_DIR")
+train_path = Path("$DATA_DIR/train.jsonl")
+train_samples = [json.loads(line) for line in train_path.open("r", encoding="utf-8")]
+label_dataset(train_samples, out_dir="$LABEL_DIR", split="train")
+
+test_path = Path("$DATA_DIR/test.jsonl")
+test_samples = [json.loads(line) for line in test_path.open("r", encoding="utf-8")]
+label_dataset(test_samples, out_dir="$DATA_DIR", split="test")
 PY
 
 # 3. Train models

--- a/test8/teacher_labeler.py
+++ b/test8/teacher_labeler.py
@@ -36,20 +36,21 @@ def call_teacher(prompt: str) -> dict[str, str]:
         return {"content": f"{{}}", "reasoning": f"[error: {e}]"}
 
 
-def label_dataset(samples: Iterable[dict], out_dir: str | Path = ".") -> None:
+def label_dataset(samples: Iterable[dict], out_dir: str | Path = ".", split: str = "train") -> None:
     """Label ``samples`` and write multitask JSONL files.
 
+    ``split`` controls the filename prefix (e.g. ``"train"`` or ``"test"``).
     Three files are produced in ``out_dir``:
-    ``train_trend.jsonl`` for prediction labels,
-    ``train_advice.jsonl`` for advice generation and
-    ``train_explain.jsonl`` for analysis/description tasks.
+    ``<split>_trend.jsonl`` for prediction labels,
+    ``<split>_advice.jsonl`` for advice generation and
+    ``<split>_explain.jsonl`` for analysis/description tasks.
     """
 
     out_path = Path(out_dir)
     out_path.mkdir(parents=True, exist_ok=True)
-    trend_f = (out_path / "train_trend.jsonl").open("w", encoding="utf-8")
-    advice_f = (out_path / "train_advice.jsonl").open("w", encoding="utf-8")
-    explain_f = (out_path / "train_explain.jsonl").open("w", encoding="utf-8")
+    trend_f = (out_path / f"{split}_trend.jsonl").open("w", encoding="utf-8")
+    advice_f = (out_path / f"{split}_advice.jsonl").open("w", encoding="utf-8")
+    explain_f = (out_path / f"{split}_explain.jsonl").open("w", encoding="utf-8")
 
     for sample in samples:
         prompt = format_prompt(sample)

--- a/test8/tests/test_dataset_builder.py
+++ b/test8/tests/test_dataset_builder.py
@@ -11,7 +11,7 @@ sys.path.append(str(Path(__file__).resolve().parents[2]))
 from test8 import dataset_builder as db
 
 
-def test_build_dataset_format_and_balance(monkeypatch):
+def test_build_dataset_format_and_balance(monkeypatch, tmp_path):
     # prepare three windows producing up, down and stable trends
     window_up = pd.DataFrame(
         {
@@ -69,10 +69,17 @@ def test_build_dataset_format_and_balance(monkeypatch):
     monkeypatch.setattr(db, "_compute_indicators", lambda df: None)
     monkeypatch.setattr(db, "_window_samples", fake_window_samples)
 
-    train, val = db.build_dataset(["000001"], days=2, window=2, val_ratio=0, seed=0)
+    train, val, test = db.build_dataset(
+        ["000001"], days=2, window=2, val_ratio=0, test_ratio=0, seed=0, out_dir=tmp_path
+    )
 
     assert val == []
+    assert test == []
     assert len(train) == 3
+    # ensure files written
+    assert (tmp_path / "train.jsonl").exists()
+    assert (tmp_path / "val.jsonl").exists()
+    assert (tmp_path / "test.jsonl").exists()
     sample = train[0]
     assert set(sample.keys()) == {
         "stock_code",


### PR DESCRIPTION
## Summary
- extend `dataset_builder.build_dataset` with optional `test_ratio` and save `test.jsonl`
- allow `teacher_labeler.label_dataset` to write split-prefixed JSONL files
- update run script and tests; include placeholder dataset files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*
- `pytest test8/tests/test_dataset_builder.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad558996c4832bab406891e119fe33