### PR TITLE
Enable low-memory training for test8 models

### DIFF
--- a/test8/run_all.sh
+++ b/test8/run_all.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+export PYTORCH_CUDA_ALLOC_CONF="expandable_segments:True"
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(dirname "$SCRIPT_DIR")"
 
@@ -37,9 +39,9 @@ label_dataset(test_samples, out_dir="$DATA_DIR", split="test")
 PY
 
 # 3. Train models
-python -m test8.scripts.train_trend_model --train "$LABEL_DIR/train_trend.jsonl" --model-out "$MODEL_DIR/trend" --log-dir "$LOG_DIR/trend" --base-model "$BASE_MODEL"
-python -m test8.scripts.train_advice_model --train "$LABEL_DIR/train_advice.jsonl" --model-out "$MODEL_DIR/advice" --log-dir "$LOG_DIR/advice" --base-model "$BASE_MODEL"
-python -m test8.scripts.train_explanation_model --train "$LABEL_DIR/train_explain.jsonl" --model-out "$MODEL_DIR/explain" --log-dir "$LOG_DIR/explain" --base-model "$BASE_MODEL"
+python -m test8.scripts.train_trend_model --train "$LABEL_DIR/train_trend.jsonl" --model-out "$MODEL_DIR/trend" --log-dir "$LOG_DIR/trend" --base-model "$BASE_MODEL" --use_lora --use_8bit
+python -m test8.scripts.train_advice_model --train "$LABEL_DIR/train_advice.jsonl" --model-out "$MODEL_DIR/advice" --log-dir "$LOG_DIR/advice" --base-model "$BASE_MODEL" --use_lora --use_8bit
+python -m test8.scripts.train_explanation_model --train "$LABEL_DIR/train_explain.jsonl" --model-out "$MODEL_DIR/explain" --log-dir "$LOG_DIR/explain" --base-model "$BASE_MODEL" --use_lora --use_8bit
 
 # 4. Merge models
 bash "$SCRIPT_DIR/merge_models.sh" "$MODEL_DIR" "$MODEL_DIR/merged"


### PR DESCRIPTION
## Summary
- prevent CUDA fragmentation by exporting `PYTORCH_CUDA_ALLOC_CONF`
- train all test8 models with LoRA and 8-bit weights to reduce GPU memory use

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aea68521c0832bb067c0f0f69a935c