### PR TITLE
Add stub PeftMixedModel for transformers compatibility

### DIFF
--- a/peft/__init__.py
+++ b/peft/__init__.py
@@ -32,6 +32,20 @@ class PeftModel(nn.Module):
         self.model.save_pretrained(save_directory, *args, **kwargs)
 
 
+class PeftMixedModel(PeftModel):
+    """Placeholder representing a model with merged PEFT adapters.
+
+    The real ``peft`` library exposes :class:`PeftMixedModel` to denote a
+    model that contains both the base and adapter weights.  The training
+    utilities from ``transformers`` import this symbol to detect whether a
+    model uses PEFT.  This lightweight stub simply inherits from
+    :class:`PeftModel` so that the import succeeds without pulling in the
+    heavy dependency.
+    """
+
+    pass
+
+
 @dataclass
 class LoraConfig:
     """Placeholder configuration container."""
@@ -52,4 +66,9 @@ def get_peft_model(model: nn.Module, config: LoraConfig) -> PeftModel:
     return PeftModel(model)
 
 
-__all__ = ["PeftModel", "LoraConfig", "get_peft_model"]
+__all__ = [
+    "PeftModel",
+    "PeftMixedModel",
+    "LoraConfig",
+    "get_peft_model",
+]


### PR DESCRIPTION
## Summary
- extend lightweight `peft` stub with `PeftMixedModel` class and export

## Testing
- `bash test8/run_all.sh` *(fails: Repo id must be in the form 'repo_name' or 'namespace/repo_name': '/workspace/llm-test2/models/base_model')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_68afb19023f0832bab7a860118ba4134