### PR TITLE
Implement teacher model API framework

### DIFF
--- a/configs/teacher_models.yaml
+++ b/configs/teacher_models.yaml
@@ -1,3 +1,12 @@
 teachers:
-  - name: placeholder_teacher
-    path: path/to/teacher/model
+  - name: deepseek
+    api_key: DEEPSEEK_API_KEY
+    base_url: https://api.deepseek.com
+    model: deepseek-chat
+  - name: qwen3
+    api_key: DASHSCOPE_API_KEY
+    base_url: https://dashscope.aliyuncs.com/compatible-mode/v1
+    model: qwen-plus
+  - name: gemini
+    api_key: GEMINI_API_KEY
+    model: gemini-2.5-flash

--- a/src/teacher_api/__init__.py
+++ b/src/teacher_api/__init__.py
@@ -1,0 +1,28 @@
+"""Factory for teacher model API implementations."""
+
+from __future__ import annotations
+
+from .base import TeacherModelAPI
+from .deepseek_api import DeepSeekAPI
+from .gemini_api import GeminiAPI
+from .qwen3_api import Qwen3API
+
+
+def get_teacher_model(name: str) -> TeacherModelAPI:
+    """Return a concrete :class:`TeacherModelAPI` implementation by name."""
+    normalized = name.lower()
+    if normalized == "deepseek":
+        return DeepSeekAPI()
+    if normalized == "qwen3":
+        return Qwen3API()
+    if normalized == "gemini":
+        return GeminiAPI()
+    raise ValueError(f"Unknown teacher model: {name}")
+
+__all__ = [
+    "TeacherModelAPI",
+    "DeepSeekAPI",
+    "Qwen3API",
+    "GeminiAPI",
+    "get_teacher_model",
+]

--- a/src/teacher_api/base.py
+++ b/src/teacher_api/base.py
@@ -1,0 +1,46 @@
+"""Base classes and utilities for teacher model APIs."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+# Default configuration path two directories above this file
+DEFAULT_CONFIG_PATH = Path(__file__).resolve().parents[2] / "configs" / "teacher_models.yaml"
+
+
+def load_teacher_config(name: str, config_path: str | Path | None = None) -> Dict[str, Any]:
+    """Load configuration for a teacher model by name.
+
+    Parameters
+    ----------
+    name: str
+        Name of the teacher model.
+    config_path: str | Path | None
+        Optional path to the configuration file. If ``None`` the default
+        ``configs/teacher_models.yaml`` relative to the project root is used.
+
+    Returns
+    -------
+    dict
+        Configuration dictionary for the requested teacher model.
+    """
+    path = Path(config_path) if config_path else DEFAULT_CONFIG_PATH
+    with path.open("r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+    for teacher in data.get("teachers", []):
+        if teacher.get("name") == name:
+            return teacher
+    raise KeyError(f"Teacher model '{name}' not found in {path}")
+
+
+class TeacherModelAPI(ABC):
+    """Abstract interface for teacher model backends."""
+
+    @abstractmethod
+    def generate_answer(self, prompt: str) -> str:
+        """Generate an answer for the given prompt."""
+        raise NotImplementedError

--- a/src/teacher_api/deepseek_api.py
+++ b/src/teacher_api/deepseek_api.py
@@ -1,0 +1,29 @@
+"""Implementation of the DeepSeek teacher model API."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from openai import OpenAI
+
+from .base import TeacherModelAPI, load_teacher_config
+
+
+class DeepSeekAPI(TeacherModelAPI):
+    """Teacher model wrapper for DeepSeek's OpenAI compatible API."""
+
+    def __init__(self, config_path: str | None = None) -> None:
+        cfg = load_teacher_config("deepseek", config_path)
+        api_key: str | None = cfg.get("api_key")
+        base_url: str | None = cfg.get("base_url")
+        self.model: str = cfg.get("model", "")
+        self.client = OpenAI(api_key=api_key, base_url=base_url)
+
+    def generate_answer(self, prompt: str) -> str:
+        """Generate an answer using DeepSeek's API."""
+        try:
+            resp: Any = self.client.responses.create(model=self.model, input=prompt)
+            return getattr(resp, "output_text", "")
+        except Exception:
+            # Return empty string on failure to keep interface simple
+            return ""

--- a/src/teacher_api/gemini_api.py
+++ b/src/teacher_api/gemini_api.py
@@ -1,0 +1,32 @@
+"""Implementation of the Gemini teacher model API."""
+
+from __future__ import annotations
+
+from typing import Any
+
+try:
+    from google import genai
+except Exception:  # pragma: no cover - optional dependency
+    genai = None  # type: ignore
+
+from .base import TeacherModelAPI, load_teacher_config
+
+
+class GeminiAPI(TeacherModelAPI):
+    """Teacher model wrapper for Google's Gemini API."""
+
+    def __init__(self, config_path: str | None = None) -> None:
+        if genai is None:
+            raise RuntimeError("google-genai package is required for GeminiAPI")
+        cfg = load_teacher_config("gemini", config_path)
+        api_key: str | None = cfg.get("api_key")
+        self.model: str = cfg.get("model", "")
+        self.client = genai.Client(api_key=api_key)
+
+    def generate_answer(self, prompt: str) -> str:
+        """Generate an answer using Gemini's API."""
+        try:
+            response: Any = self.client.models.generate_content(self.model, prompt)
+            return getattr(response, "text", "")
+        except Exception:
+            return ""

--- a/src/teacher_api/qwen3_api.py
+++ b/src/teacher_api/qwen3_api.py
@@ -1,0 +1,31 @@
+"""Implementation of the Qwen3 teacher model API."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from openai import OpenAI
+
+from .base import TeacherModelAPI, load_teacher_config
+
+
+class Qwen3API(TeacherModelAPI):
+    """Teacher model wrapper for Qwen3 using the DashScope compatible API."""
+
+    def __init__(self, config_path: str | None = None) -> None:
+        cfg = load_teacher_config("qwen3", config_path)
+        api_key: str | None = cfg.get("api_key")
+        base_url: str | None = cfg.get("base_url")
+        self.model: str = cfg.get("model", "")
+        self.client = OpenAI(api_key=api_key, base_url=base_url)
+
+    def generate_answer(self, prompt: str) -> str:
+        """Generate an answer using Qwen3's API."""
+        try:
+            resp: Any = self.client.chat.completions.create(
+                model=self.model, messages=[{"role": "user", "content": prompt}]
+            )
+            message = resp.choices[0].message
+            return getattr(message, "content", "")
+        except Exception:
+            return ""


### PR DESCRIPTION
## Summary
- define abstract `TeacherModelAPI` with config loader
- add DeepSeek, Qwen3, and Gemini API implementations
- add factory to select teacher model and expand teacher model configs

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'src')*


------
https://chatgpt.com/codex/tasks/task_e_68b1713ae478832bb03ba1e35bfd8037