### PR TITLE
Add dataset utilities with tokenization masking and tests

### DIFF
--- a/test9/src/data_utils.py
+++ b/test9/src/data_utils.py
@@ -1,0 +1,62 @@
+import json
+from typing import List, Dict, Any, Tuple
+
+try:
+    from datasets import Dataset
+except Exception:  # pragma: no cover - datasets not installed
+    Dataset = None  # type: ignore
+
+def load_dataset(path: str):
+    """Load a JSONL dataset.
+
+    Each line of the file at ``path`` should contain a JSON object with at
+    least ``prompt`` and ``completion`` fields. The function returns a list of
+    dictionaries representing the examples. If the optional :mod:`datasets`
+    package is available, the caller may convert the list to a
+    :class:`datasets.Dataset` via ``Dataset.from_list``.
+    """
+    data: List[Dict[str, Any]] = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            data.append(json.loads(line))
+    return data
+
+def preprocess_example(example: Dict[str, Any], tokenizer):
+    """Tokenize an example for causal language modeling.
+
+    The ``example`` must provide ``prompt`` and ``completion`` strings. These
+    are concatenated and tokenized with ``tokenizer``. Tokens corresponding to
+    the prompt are masked in the ``labels`` field with ``-100`` so that only
+    completion tokens contribute to the loss during training.
+    """
+    prompt = example["prompt"]
+    completion = example["completion"]
+    text = prompt + completion
+
+    prompt_tokens = tokenizer(prompt, add_special_tokens=False)["input_ids"]
+    tokenized = tokenizer(text, add_special_tokens=True)
+    labels = tokenized["input_ids"].copy()
+    prompt_len = len(prompt_tokens)
+    labels[:prompt_len] = [-100] * prompt_len
+    tokenized["labels"] = labels
+    return tokenized
+
+def make_datasets(train_path: str, val_path: str, tokenizer) -> Tuple[Dataset, Dataset]:
+    """Load and preprocess training and validation datasets.
+
+    ``train_path`` and ``val_path`` should point to JSONL files formatted for
+    :func:`load_dataset`. The returned datasets contain tokenized examples
+    suitable for training causal language models.
+    """
+    if Dataset is None:  # pragma: no cover - handled in environments without datasets
+        raise ImportError("datasets library is required for make_datasets")
+
+    train_raw = load_dataset(train_path)
+    val_raw = load_dataset(val_path)
+
+    train_ds = Dataset.from_list([preprocess_example(ex, tokenizer) for ex in train_raw])
+    val_ds = Dataset.from_list([preprocess_example(ex, tokenizer) for ex in val_raw])
+    return train_ds, val_ds

--- a/tests/test9/test_data_utils.py
+++ b/tests/test9/test_data_utils.py
@@ -1,0 +1,71 @@
+import json
+import sys
+from pathlib import Path
+
+# Add test9/src to sys.path
+sys.path.append(str(Path(__file__).resolve().parents[2] / 'test9' / 'src'))
+
+from data_utils import load_dataset, preprocess_example, make_datasets
+
+
+class DummyTokenizer:
+    """A minimal whitespace tokenizer for testing."""
+
+    def __init__(self):
+        self.vocab = {}
+        self.next_id = 1
+        self.eos_token_id = 0
+
+    def _tokenize(self, text):
+        tokens = text.strip().split()
+        ids = []
+        for tok in tokens:
+            if tok not in self.vocab:
+                self.vocab[tok] = self.next_id
+                self.next_id += 1
+            ids.append(self.vocab[tok])
+        return ids
+
+    def __call__(self, text, add_special_tokens=True):
+        ids = self._tokenize(text)
+        if add_special_tokens:
+            ids = ids + [self.eos_token_id]
+        return {"input_ids": ids}
+
+
+def test_load_dataset(tmp_path):
+    path = tmp_path / 'data.jsonl'
+    examples = [
+        {"prompt": "hello", "completion": " world"},
+        {"prompt": "foo", "completion": " bar"},
+    ]
+    with open(path, 'w', encoding='utf-8') as f:
+        for ex in examples:
+            f.write(json.dumps(ex) + '\n')
+
+    data = load_dataset(str(path))
+    assert isinstance(data, list)
+    assert data == examples
+
+
+def test_preprocess_example_masking():
+    tokenizer = DummyTokenizer()
+    example = {"prompt": "hello", "completion": " world"}
+    out = preprocess_example(example, tokenizer)
+    assert out["input_ids"] == [1, 2, 0]
+    assert out["labels"] == [-100, 2, 0]
+
+
+def test_make_datasets(tmp_path):
+    tokenizer = DummyTokenizer()
+    train_path = tmp_path / 'train.jsonl'
+    val_path = tmp_path / 'val.jsonl'
+    data = {"prompt": "hi", "completion": " there"}
+    for p in (train_path, val_path):
+        with open(p, 'w', encoding='utf-8') as f:
+            f.write(json.dumps(data) + '\n')
+
+    train_ds, val_ds = make_datasets(str(train_path), str(val_path), tokenizer)
+    assert len(train_ds) == 1
+    assert train_ds[0]["labels"][0] == -100
+    assert len(val_ds) == 1


### PR DESCRIPTION
## Summary
- add JSONL loader and preprocessing helpers for prompt-completion datasets
- provide dataset construction helper that tokenizes and masks prompts
- add unit tests covering JSON parsing and token masking

## Testing
- `pytest tests/test9/test_data_utils.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src' in test7 tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b2fa9ddc832b88724b74656b905a