### PR TITLE
feat(test9): add training helpers

### DIFF
--- a/test9/src/training/__init__.py
+++ b/test9/src/training/__init__.py
@@ -1,0 +1,19 @@
+"""Training utilities for the ``test9`` exercises.
+
+The submodules provide light‑weight stand‑ins for the actual training helpers
+used in the main project.  Only a very small public API is exported via
+``__all__`` so that unit tests can import the pieces they need without pulling
+in heavy dependencies.
+"""
+
+from .sft_trainer import SFTDataCollator, SFTTrainer
+from .ppo_trainer import compute_rewards, generate_responses, ppo_step
+
+__all__ = [
+    "SFTDataCollator",
+    "SFTTrainer",
+    "compute_rewards",
+    "generate_responses",
+    "ppo_step",
+]
+

--- a/test9/src/training/ppo_trainer.py
+++ b/test9/src/training/ppo_trainer.py
@@ -1,0 +1,112 @@
+"""Helper wrappers around :class:`trl.PPOTrainer`.
+
+The real project performs reinforcement learning using the `trl` package.  In
+the exercises found in this repository we only need small convenience
+functions to glue together generation, reward computation and the PPO update
+step.  These wrappers keep the actual training loop in the tests concise while
+remaining importable even if optional dependencies are absent.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Iterable, List, Sequence, Tuple
+
+try:  # pragma: no cover - optional dependency
+    from trl import PPOTrainer
+except Exception:  # pragma: no cover - TRL not installed
+    PPOTrainer = object  # type: ignore
+
+try:  # pragma: no cover - torch is optional
+    import torch
+except Exception:  # pragma: no cover - torch not installed
+    torch = None  # type: ignore
+
+
+# ---------------------------------------------------------------------------
+# Generation utilities
+# ---------------------------------------------------------------------------
+
+
+def generate_responses(
+    trainer: PPOTrainer, prompts: Sequence[str], generation_kwargs: dict | None = None
+) -> List[str]:
+    """Generate model responses for ``prompts``.
+
+    The helper delegates to ``trainer.model.generate`` and decodes the output
+    using ``trainer.tokenizer``.  Only the small subset of arguments required
+    in the tests is supported.  When :mod:`torch` is unavailable the function
+    falls back to a minimal implementation returning raw token IDs.
+    """
+
+    if getattr(trainer, "model", None) is None or getattr(trainer, "tokenizer", None) is None:
+        raise RuntimeError("trainer must expose 'model' and 'tokenizer' attributes")
+
+    gen_kwargs = generation_kwargs or {}
+    tokenised = trainer.tokenizer(list(prompts), return_tensors="pt", padding=True)
+    input_ids = tokenised["input_ids"]
+    if torch is not None and hasattr(trainer.model, "device"):
+        input_ids = input_ids.to(trainer.model.device)
+
+    output_ids = trainer.model.generate(input_ids=input_ids, **gen_kwargs)
+
+    if torch is not None:
+        return trainer.tokenizer.batch_decode(output_ids, skip_special_tokens=True)
+    # Fallback – return raw token ids to keep behaviour predictable
+    return [ids for ids in output_ids.tolist()]
+
+
+# ---------------------------------------------------------------------------
+# Reward calculation
+# ---------------------------------------------------------------------------
+
+
+def compute_rewards(reward_fn: Callable[[str], float], responses: Iterable[str]) -> List[float]:
+    """Evaluate ``reward_fn`` for each response."""
+
+    return [float(reward_fn(resp)) for resp in responses]
+
+
+# ---------------------------------------------------------------------------
+# PPO update step
+# ---------------------------------------------------------------------------
+
+
+def ppo_step(
+    trainer: PPOTrainer,
+    prompts: Sequence[str],
+    reward_fn: Callable[[str], float],
+    generation_kwargs: dict | None = None,
+) -> Tuple[List[str], List[float]]:
+    """Run a single PPO optimisation step.
+
+    Parameters
+    ----------
+    trainer:
+        Instance of :class:`trl.PPOTrainer`.
+    prompts:
+        Sequence of input prompts fed to the model.
+    reward_fn:
+        Callable computing a reward from the generated text.
+    generation_kwargs:
+        Optional keyword arguments forwarded to
+        :meth:`transformers.PreTrainedModel.generate`.
+
+    Returns
+    -------
+    Tuple[List[str], List[float]]
+        The generated responses and the corresponding rewards.
+    """
+
+    responses = generate_responses(trainer, prompts, generation_kwargs)
+    rewards = compute_rewards(reward_fn, responses)
+
+    # The PPO trainer expects tensors of token IDs.  For the purposes of the
+    # unit tests the prompts and responses are fed in as raw strings which the
+    # trainer knows how to tokenise internally.
+    trainer.step(prompts, responses, rewards)
+
+    return responses, rewards
+
+
+__all__ = ["generate_responses", "compute_rewards", "ppo_step"]
+

--- a/test9/src/training/sft_trainer.py
+++ b/test9/src/training/sft_trainer.py
@@ -1,0 +1,84 @@
+"""Light‑weight utilities for supervised fine‑tuning (SFT).
+
+The real project uses :class:`~transformers.Trainer` with a custom data
+collator.  For the unit tests in this kata we provide a greatly simplified
+implementation that mirrors the public API while remaining importable even if
+optional dependencies such as :mod:`torch` or :mod:`transformers` are missing.
+The goal is to make the helpers easy to understand and dependable for small
+experiments.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List
+
+try:  # pragma: no cover - transformers is an optional dependency
+    from transformers import Trainer
+except Exception:  # pragma: no cover - transformers not installed
+    Trainer = object  # type: ignore
+
+try:  # pragma: no cover - torch is optional
+    import torch
+except Exception:  # pragma: no cover - torch not installed
+    torch = None  # type: ignore
+
+
+# ---------------------------------------------------------------------------
+# Data collator
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SFTDataCollator:
+    """Minimal data collator for supervised fine‑tuning.
+
+    The collator simply pads ``input_ids`` using the provided tokenizer and
+    copies them to ``labels`` so that the language model is trained to predict
+    the next token.  If either :mod:`torch` or a tokenizer with a ``pad``
+    method is unavailable, the features are returned unchanged to keep the
+    behaviour predictable in the test environment.
+    """
+
+    tokenizer: Any
+
+    def __call__(self, features: Iterable[Dict[str, Any]]) -> Dict[str, Any]:
+        features = list(features)
+
+        if getattr(self.tokenizer, "pad", None) and torch is not None:
+            batch = self.tokenizer.pad(features, padding=True, return_tensors="pt")
+            batch["labels"] = batch["input_ids"].clone()
+            return batch
+
+        # Fallback – return simple lists so tests can still inspect the output
+        input_ids: List[Any] = [f["input_ids"] for f in features]
+        return {"input_ids": input_ids, "labels": input_ids}
+
+
+# ---------------------------------------------------------------------------
+# Trainer wrapper
+# ---------------------------------------------------------------------------
+
+
+class SFTTrainer(Trainer):
+    """Thin wrapper around :class:`~transformers.Trainer` with a default
+    :class:`SFTDataCollator`.
+
+    The wrapper injects :class:`SFTDataCollator` when a ``data_collator`` is not
+    explicitly provided.  This keeps the public API similar to the real
+    training code while remaining small enough for unit testing.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover -
+        # runtime behaviour depends on optional dependencies
+        if Trainer is object:
+            raise RuntimeError("transformers is required to use SFTTrainer")
+
+        if "data_collator" not in kwargs and "tokenizer" in kwargs:
+            kwargs["data_collator"] = SFTDataCollator(kwargs["tokenizer"])
+
+        super().__init__(*args, **kwargs)  # type: ignore[misc]
+
+
+__all__ = ["SFTDataCollator", "SFTTrainer"]
+


### PR DESCRIPTION
## Summary
- add lightweight SFTTrainer and data collator utilities
- provide wrappers around TRL's PPOTrainer for generation, reward, and update steps
- expose training helpers via `training.__all__`

## Testing
- `pytest tests/test9/test_data_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6b9acb2cc832b9a01b7ae752ddb87