### PR TITLE
Add training and inference scripts for test9

### DIFF
--- a/test9/configs/ppo_config.yaml
+++ b/test9/configs/ppo_config.yaml
@@ -1,0 +1,9 @@
+model_name: gpt2
+sft_model_path: ../models/sft
+prompt_path: ../data/train.jsonl
+output_dir: ../models/ppo
+ppo_config:
+  batch_size: 1
+  learning_rate: 1.0e-5
+  log_with: null
+  max_new_tokens: 32

--- a/test9/configs/sft_config.yaml
+++ b/test9/configs/sft_config.yaml
@@ -1,0 +1,9 @@
+model_name: gpt2
+train_path: ../data/train.jsonl
+val_path: ../data/val.jsonl
+training_args:
+  num_train_epochs: 1
+  per_device_train_batch_size: 1
+  per_device_eval_batch_size: 1
+  logging_steps: 1
+  save_strategy: "no"

--- a/test9/scripts/evaluate.py
+++ b/test9/scripts/evaluate.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+"""Evaluate a PPO model on a held-out dataset."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from model_utils import load_model, load_tokenizer
+from data_utils import load_dataset
+from evaluation import evaluate_dataset
+
+
+def evaluate(model_path: str, test_path: str, max_new_tokens: int = 64) -> None:
+    tokenizer = load_tokenizer(model_path)
+    model = load_model(model_path)
+
+    data = load_dataset(test_path)
+    outputs = []
+    references = []
+    for ex in data:
+        inputs = tokenizer(ex["prompt"], return_tensors="pt")
+        ids = model.generate(**inputs, max_new_tokens=max_new_tokens)
+        text = tokenizer.decode(ids[0], skip_special_tokens=True)
+        outputs.append(text)
+        references.append(ex.get("completion"))
+
+    metrics = evaluate_dataset(outputs, references)
+    print(json.dumps(metrics, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Evaluate model outputs")
+    default_model = Path(__file__).resolve().parent.parent / "models" / "ppo"
+    default_test = Path(__file__).resolve().parent.parent / "data" / "test.jsonl"
+    parser.add_argument("--model-path", type=str, default=str(default_model))
+    parser.add_argument("--test-path", type=str, default=str(default_test))
+    parser.add_argument("--max-new-tokens", type=int, default=64)
+    args = parser.parse_args()
+
+    evaluate(args.model_path, args.test_path, args.max_new_tokens)

--- a/test9/scripts/infer.py
+++ b/test9/scripts/infer.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+"""Inference script for PPO fine-tuned models."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import List
+
+from model_utils import load_model, load_tokenizer
+
+
+def generate(prompts: List[str], model_path: str, max_new_tokens: int = 64) -> None:
+    tokenizer = load_tokenizer(model_path)
+    model = load_model(model_path)
+
+    for prompt in prompts:
+        inputs = tokenizer(prompt, return_tensors="pt")
+        output_ids = model.generate(**inputs, max_new_tokens=max_new_tokens)
+        text = tokenizer.decode(output_ids[0], skip_special_tokens=True)
+        try:
+            obj = json.loads(text)
+        except json.JSONDecodeError:
+            obj = {"text": text}
+        print(json.dumps(obj, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run inference with a PPO model")
+    default_model = Path(__file__).resolve().parent.parent / "models" / "ppo"
+    parser.add_argument("prompt", nargs="*", help="Prompt strings")
+    parser.add_argument("--model-path", type=str, default=str(default_model))
+    parser.add_argument("--input-file", type=str, help="File containing prompts", default=None)
+    parser.add_argument("--max-new-tokens", type=int, default=64)
+    args = parser.parse_args()
+
+    prompts = list(args.prompt)
+    if args.input_file:
+        with open(args.input_file, "r", encoding="utf-8") as f:
+            prompts.extend([line.strip() for line in f if line.strip()])
+
+    if not prompts:
+        raise SystemExit("No prompts provided")
+
+    generate(prompts, args.model_path, args.max_new_tokens)

--- a/test9/scripts/train_ppo.py
+++ b/test9/scripts/train_ppo.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+"""Minimal PPO fine-tuning script.
+
+The script loads a supervised fine-tuned checkpoint and further trains it
+with a reward signal defined in ``src/reward.py`` using the ``trl``
+``PPOTrainer``.  The implementation is intentionally compact so that unit
+tests can execute quickly.
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import yaml
+
+from model_utils import load_model, load_tokenizer, save_model
+from data_utils import load_dataset
+from reward import calculate_reward
+
+try:  # pragma: no cover - optional dependency
+    from trl import PPOTrainer, PPOConfig
+except Exception:  # pragma: no cover - trl not installed
+    PPOTrainer = PPOConfig = None  # type: ignore
+
+
+def train_ppo(config_path: str) -> None:
+    with open(config_path, "r", encoding="utf-8") as f:
+        cfg = yaml.safe_load(f)
+
+    cfg_dir = Path(config_path).parent
+    model_name = cfg["model_name"]
+    sft_model_path = (cfg_dir / cfg.get("sft_model_path", "../models/sft")).resolve()
+    prompt_path = (cfg_dir / cfg["prompt_path"]).resolve()
+    output_dir = (cfg_dir / cfg.get("output_dir", "../models/ppo")).resolve()
+    ppo_cfg = cfg.get("ppo_config", {})
+
+    if PPOTrainer is None:  # pragma: no cover - handled when trl missing
+        raise ImportError("trl library is required for PPO training")
+
+    tokenizer = load_tokenizer(str(sft_model_path) if sft_model_path.exists() else model_name)
+    model = load_model(str(sft_model_path) if sft_model_path.exists() else model_name)
+
+    ppo_config = PPOConfig(**ppo_cfg)
+    trainer = PPOTrainer(ppo_config, model, tokenizer)
+
+    prompts = [ex["prompt"] for ex in load_dataset(str(prompt_path))]
+    gen_kwargs = {"max_new_tokens": ppo_cfg.get("max_new_tokens", 32)}
+
+    for prompt in prompts:
+        query = tokenizer(prompt, return_tensors="pt")["input_ids"]
+        response = trainer.generate(query, **gen_kwargs)
+        text = tokenizer.decode(response[0], skip_special_tokens=True)
+        reward = calculate_reward(text)
+        trainer.step([query[0]], [response[0]], [reward])
+
+    save_model(trainer.model, tokenizer, output_dir)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="PPO fine-tuning")
+    default_cfg = Path(__file__).resolve().parent.parent / "configs" / "ppo_config.yaml"
+    parser.add_argument("--config", type=str, default=str(default_cfg))
+    args = parser.parse_args()
+    train_ppo(args.config)

--- a/test9/scripts/train_sft.py
+++ b/test9/scripts/train_sft.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+"""Simple supervised fine-tuning entry point.
+
+The script wires together helper utilities defined in ``test9/src`` to
+train a language model with Hugging Face's ``Trainer``.  It loads a YAML
+configuration, prepares datasets and persists the resulting checkpoint.
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import yaml
+
+from model_utils import load_model, load_tokenizer, save_model
+from data_utils import make_datasets
+
+try:  # pragma: no cover - optional dependency
+    from transformers import (
+        Trainer,
+        TrainingArguments,
+        DataCollatorForLanguageModeling,
+    )
+except Exception:  # pragma: no cover - transformers not installed
+    Trainer = TrainingArguments = DataCollatorForLanguageModeling = None  # type: ignore
+
+
+def train_sft(config_path: str, output_dir: str) -> None:
+    """Train a model using supervised fine-tuning."""
+    with open(config_path, "r", encoding="utf-8") as f:
+        cfg = yaml.safe_load(f)
+
+    cfg_dir = Path(config_path).parent
+    model_name = cfg["model_name"]
+    train_path = (cfg_dir / cfg["train_path"]).resolve()
+    val_path = (cfg_dir / cfg["val_path"]).resolve()
+    training_args_cfg = cfg.get("training_args", {})
+
+    tokenizer = load_tokenizer(model_name)
+    model = load_model(model_name)
+
+    train_ds, val_ds = make_datasets(str(train_path), str(val_path), tokenizer)
+
+    if Trainer is None:  # pragma: no cover - handled in environments without transformers
+        raise ImportError("transformers library is required for training")
+
+    data_collator = DataCollatorForLanguageModeling(tokenizer, mlm=False)
+    args = TrainingArguments(output_dir=output_dir, **training_args_cfg)
+    trainer = Trainer(
+        model=model,
+        args=args,
+        tokenizer=tokenizer,
+        data_collator=data_collator,
+        train_dataset=train_ds,
+        eval_dataset=val_ds,
+    )
+    trainer.train()
+    save_model(model, tokenizer, output_dir)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Supervised fine-tuning")
+    default_cfg = Path(__file__).resolve().parent.parent / "configs" / "sft_config.yaml"
+    default_out = Path(__file__).resolve().parent.parent / "models" / "sft"
+    parser.add_argument("--config", type=str, default=str(default_cfg))
+    parser.add_argument("--output_dir", type=str, default=str(default_out))
+    args = parser.parse_args()
+    train_sft(args.config, args.output_dir)


### PR DESCRIPTION
## Summary
- implement supervised fine-tuning, PPO training, inference, and evaluation scripts in `test9/scripts`
- add example SFT and PPO configuration files

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_68b6bb86f3c4832bad91f32e4d7fcb4e