### PR TITLE
docs: expand test9 README with workflow instructions

### DIFF
--- a/test9/README.md
+++ b/test9/README.md
@@ -1,24 +1,59 @@
-# Test9 Project Skeleton
+# Test9 Project
 
-This directory provides a minimal scaffold for experimenting with supervised fine-tuning and reinforcement learning for language models.
+## Overview
 
-## Structure
-- **data/**: placeholders for training, validation, and test data.
-- **configs/**: sample configuration files for SFT, PPO, and reward modeling.
-- **src/**: module stubs for data processing, models, rewards, and evaluation utilities.
-- **src/training/**: trainer stubs for SFT and PPO workflows.
-- **scripts/**: entry points for training, inference, and evaluation.
+`test9` contains a compact end-to-end example for reinforcement learning from
+human feedback (RLHF) built around stock price movement data.  The workflow
+covers:
+
+1. generating labelled training data,
+2. supervised fine-tuning (SFT) of a base language model,
+3. reinforcement learning with Proximal Policy Optimization (PPO),
+4. inference and evaluation of the resulting model.
+
+The code is intentionally lightweight so that each stage can be run on a
+single GPU or even CPU for very small experiments.
+
+## Directory Map
+
+```
+test9/
+├── configs/   # YAML and JSON configs for training and reward shaping
+├── data/      # Generated train/val/test datasets
+├── scripts/   # Command line entry points for the workflow
+├── src/       # Library code (data, models, reward, evaluation, training)
+└── README.md  # This file
+```
+
+Trained checkpoints are written to a `models/` directory when running the
+training scripts.
+
+## Prerequisites
+
+- Python 3.10+
+- [PyTorch](https://pytorch.org/) with CUDA support for GPU training
+- `transformers`, `datasets`, `trl`, and `peft` libraries
+- At least 12 GB of GPU memory is recommended for full training runs; the code
+  will fall back to CPU where possible for quick tests.
+
+### Environment setup
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt  # run from repository root
+```
 
 ## Data Generation
-Run the helper below to download recent K-line data and build training,
-validation and test splits:
+
+Download recent K-line price data and build the train/validation/test splits:
 
 ```bash
 python scripts/generate_data.py
 ```
 
-The script pulls roughly 120 days of prices for the stock codes defined in
-[`test4/config.py`](../test4/config.py). It extracts sliding 30‑day windows,
+The helper pulls roughly 120 days of prices for the stock codes defined in
+[`test4/config.py`](../test4/config.py).  It extracts sliding 30‑day windows,
 derives a simple up/down/stable label and writes three JSONL files under
 `data/`:
 
@@ -26,12 +61,68 @@ derives a simple up/down/stable label and writes three JSONL files under
 - `val.jsonl`
 - `test.jsonl`
 
-Each line in these files has the form:
+Each line has the format:
 
 ```json
 {"prompt": "<30-day K-line data>", "completion": "{\"prediction\":...,\"analysis\":...,\"advice\":...}"}
 ```
 
-## Usage
-Populate the data and configuration files, implement the module contents, then
-run the scripts to train and evaluate models.
+## Supervised Fine-Tuning (SFT)
+
+Train a base model on the generated data:
+
+```bash
+python scripts/train_sft.py --config configs/sft_config.yaml --output_dir models/sft
+```
+
+The YAML config selects the model, data files and `transformers` training
+arguments.  The resulting checkpoint is saved under `models/sft`.
+
+## PPO Training
+
+Further optimise the SFT model with a reward function:
+
+```bash
+python scripts/train_ppo.py --config configs/ppo_config.yaml
+```
+
+The script loads the SFT checkpoint, generates responses for prompts in
+`data/train.jsonl`, scores them with `src/reward.py` and performs PPO updates.
+The fine-tuned model is saved to `models/ppo` by default.
+
+## Inference
+
+Generate predictions with the PPO model:
+
+```bash
+python scripts/infer.py --model-path models/ppo "<your prompt here>"
+# or read prompts from a file
+python scripts/infer.py --model-path models/ppo --input-file prompts.txt
+```
+
+Outputs are printed as JSON objects on stdout.
+
+## Evaluation
+
+Score model outputs on the held-out test set:
+
+```bash
+python scripts/evaluate.py --model-path models/ppo --test-path data/test.jsonl
+```
+
+The script validates JSON format and required fields, reporting aggregate
+statistics such as accuracy of required keys.
+
+## References
+
+- [Proximal Policy Optimization Algorithms](https://arxiv.org/abs/1707.06347)
+  (Schulman et al., 2017)
+- [LoRA: Low-Rank Adaptation of Large Language Models](https://arxiv.org/abs/2106.09685)
+  (Hu et al., 2021)
+- [Training language models to follow instructions with human feedback](https://arxiv.org/abs/2203.02155)
+  (Ouyang et al., 2022)
+- [TRL – Transformer Reinforcement Learning library](https://github.com/huggingface/trl)
+
+These resources informed the overall design and algorithms used in this
+project.
+


### PR DESCRIPTION
## Summary
- document project overview, directory map, and workflow in `test9` README
- add instructions for data generation, SFT, PPO, inference, evaluation, and env setup
- cite core RLHF resources that inspired the design

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'src' in test7)*

------
https://chatgpt.com/codex/tasks/task_e_68b6bd539c00832ba9359cffedaff8fb